### PR TITLE
Rename Glossator to Remarq

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Glossator — Claude Code Instructions
+# Remarq — Claude Code Instructions
 
 ## Git Workflow (Required for All Meaningful Work)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Glossator
+# Remarq
 
 Lightweight document annotation tool. Reviewers highlight text and leave threaded comments — no accounts needed, just enter a name. Authors collect the feedback and send it to Claude for AI-assisted revision.
 
@@ -37,7 +37,7 @@ That's it. The sidebar, text selection, highlights, and annotation UI are all ha
 
 | Attribute | Default | Description |
 |-----------|---------|-------------|
-| `data-api-url` | `""` (same origin) | URL of the Glossator backend |
+| `data-api-url` | `""` (same origin) | URL of the Remarq backend |
 | `data-content-selector` | `body` | CSS selector for the annotatable content area |
 | `data-document-uri` | current page URL | Override the URI used to store/fetch annotations |
 
@@ -68,12 +68,12 @@ PORT=8080 npm start
 
 ```ini
 [Unit]
-Description=Glossator annotation server
+Description=Remarq annotation server
 After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/path/to/glossator
+WorkingDirectory=/path/to/remarq
 ExecStart=/usr/bin/node server/index.js
 Environment=PORT=3333
 Restart=on-failure
@@ -87,7 +87,7 @@ WantedBy=multi-user.target
 ```nginx
 server {
     listen 443 ssl;
-    server_name glossator.example.com;
+    server_name remarq.example.com;
 
     location /api/ {
         proxy_pass http://127.0.0.1:3333;
@@ -103,8 +103,8 @@ Then on your pages:
 
 ```html
 <script
-  src="https://glossator.example.com/feedback-layer.js"
-  data-api-url="https://glossator.example.com"
+  src="https://remarq.example.com/feedback-layer.js"
+  data-api-url="https://remarq.example.com"
   data-content-selector="article"
 ></script>
 ```
@@ -171,7 +171,7 @@ For replies, set `parent_id` to the parent annotation's ID. Replies don't need `
 ## Project Structure
 
 ```
-glossator/
+remarq/
 ├── package.json              # Root: npm install + npm start
 ├── server/
 │   ├── package.json          # express, better-sqlite3, cors, uuid

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# Glossator TODO
+# Remarq TODO
 
 ## 🐛 Bugs / Issues
 - [ ] Test with very long documents (performance)

--- a/feedback-layer/CHANGELOG.md
+++ b/feedback-layer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Glossator will be documented in this file.
+All notable changes to Remarq will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/feedback-layer/README.md
+++ b/feedback-layer/README.md
@@ -1,8 +1,8 @@
-# Glossator
+# Remarq
 
 Lightweight annotation and feedback layer for HTML documents. Add collaborative commenting, highlighting, and threaded discussions to any webpage.
 
-![Glossator Demo](https://via.placeholder.com/800x400?text=Glossator+Demo)
+![Remarq Demo](https://via.placeholder.com/800x400?text=Remarq+Demo)
 
 ## Features
 
@@ -22,7 +22,7 @@ Just add one script tag to your HTML:
 
 ```html
 <script
-  src="https://unpkg.com/glossator@1/dist/feedback-layer.js"
+  src="https://unpkg.com/remarq@1/dist/feedback-layer.js"
   data-api-url="http://localhost:3333"
   data-content-selector="article"
 ></script>
@@ -31,13 +31,13 @@ Just add one script tag to your HTML:
 ### Option 2: NPM
 
 ```bash
-npm install glossator
+npm install remarq
 ```
 
 Copy the built file to your public directory:
 
 ```bash
-cp node_modules/glossator/dist/feedback-layer.js public/
+cp node_modules/remarq/dist/feedback-layer.js public/
 ```
 
 Then add to your HTML:
@@ -65,7 +65,7 @@ Configure via data attributes on the script tag:
 **Annotate just the main article:**
 ```html
 <script
-  src="https://unpkg.com/glossator@1/dist/feedback-layer.js"
+  src="https://unpkg.com/remarq@1/dist/feedback-layer.js"
   data-api-url="http://localhost:3333"
   data-content-selector="article"
 ></script>
@@ -74,7 +74,7 @@ Configure via data attributes on the script tag:
 **Annotate a specific div:**
 ```html
 <script
-  src="https://unpkg.com/glossator@1/dist/feedback-layer.js"
+  src="https://unpkg.com/remarq@1/dist/feedback-layer.js"
   data-api-url="http://localhost:3333"
   data-content-selector=".content"
 ></script>
@@ -83,7 +83,7 @@ Configure via data attributes on the script tag:
 **Multiple documents on same domain:**
 ```html
 <script
-  src="https://unpkg.com/glossator@1/dist/feedback-layer.js"
+  src="https://unpkg.com/remarq@1/dist/feedback-layer.js"
   data-api-url="http://localhost:3333"
   data-content-selector="article"
   data-document-uri="/docs/getting-started"
@@ -92,7 +92,7 @@ Configure via data attributes on the script tag:
 
 ## Annotation Server
 
-Glossator requires a backend server to store annotations.
+Remarq requires a backend server to store annotations.
 
 ### Quick Start with the Example Server
 
@@ -100,8 +100,8 @@ Clone the repository and run the included server:
 
 ```bash
 # Clone the repo
-git clone https://github.com/yourusername/glossator.git
-cd glossator/server
+git clone https://github.com/cass-clearly/remarq.git
+cd remarq/server
 
 # Start the server
 npm install
@@ -144,8 +144,8 @@ See the [API specification](./server/README.md) for details.
 
 ```bash
 # Clone the repo
-git clone https://github.com/yourusername/glossator.git
-cd glossator/feedback-layer
+git clone https://github.com/cass-clearly/remarq.git
+cd remarq/feedback-layer
 
 # Install dependencies
 npm install

--- a/feedback-layer/package.json
+++ b/feedback-layer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "glossator",
+  "name": "remarq",
   "version": "1.1.0",
   "description": "Lightweight annotation and feedback layer for HTML documents. Add collaborative commenting, highlighting, and threaded discussions to any webpage.",
   "main": "dist/feedback-layer.js",
@@ -27,12 +27,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yourusername/glossator.git"
+    "url": "https://github.com/cass-clearly/remarq.git"
   },
   "bugs": {
-    "url": "https://github.com/yourusername/glossator/issues"
+    "url": "https://github.com/cass-clearly/remarq/issues"
   },
-  "homepage": "https://github.com/yourusername/glossator#readme",
+  "homepage": "https://github.com/cass-clearly/remarq#readme",
   "dependencies": {
     "@apache-annotator/dom": "^0.2.0",
     "@apache-annotator/selector": "^0.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "remarq",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "remarq",
+      "version": "1.1.0",
+      "hasInstallScript": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "glossator",
+  "name": "remarq",
   "version": "1.1.0",
   "private": true,
   "description": "Drop-in annotation and comment layer for any HTML page.",

--- a/serve/index.html
+++ b/serve/index.html
@@ -72,7 +72,7 @@
 
   <h2>System Architecture</h2>
   <p>
-    Glossator implements a client-server architecture where annotations are anchored to
+    Remarq implements a client-server architecture where annotations are anchored to
     text using TextQuoteSelector and stored in a backend database. Try selecting and annotating
     text in the diagram below to test annotation support for dynamically-rendered content.
   </p>
@@ -135,23 +135,23 @@ graph TB
 sequenceDiagram
     participant Author
     participant Reviewer
-    participant Glossator
+    participant Remarq
     participant Server
 
-    Author->>Glossator: Publish document
-    Reviewer->>Glossator: Select text
-    Glossator->>Reviewer: Show ✎ Annotate
-    Reviewer->>Glossator: Add comment
-    Glossator->>Server: POST /api/annotations
-    Server-->>Glossator: Save annotation
-    Glossator->>Glossator: Highlight text
+    Author->>Remarq: Publish document
+    Reviewer->>Remarq: Select text
+    Remarq->>Reviewer: Show ✎ Annotate
+    Reviewer->>Remarq: Add comment
+    Remarq->>Server: POST /api/annotations
+    Server-->>Remarq: Save annotation
+    Remarq->>Remarq: Highlight text
 
-    Reviewer->>Glossator: Click highlight
-    Glossator->>Glossator: Open sidebar
+    Reviewer->>Remarq: Click highlight
+    Remarq->>Remarq: Open sidebar
 
-    Author->>Glossator: Resolve ✓
-    Glossator->>Server: PATCH (resolved)
-    Glossator->>Glossator: Remove highlight
+    Author->>Remarq: Resolve ✓
+    Remarq->>Server: PATCH (resolved)
+    Remarq->>Remarq: Remove highlight
   </pre>
 
   <p>
@@ -263,7 +263,7 @@ erDiagram
 
   <pre class="mermaid">
 gantt
-    title Glossator Development Timeline
+    title Remarq Development Timeline
     dateFormat YYYY-MM-DD
     section Planning
     Requirements gathering       :done, req, 2024-01-01, 7d

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "annotation-server",
+  "name": "remarq-server",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- Renames the project from "Glossator" to "Remarq" across all in-repo references
- Updates package names in root, feedback-layer, and server package.json files
- Updates README.md, feedback-layer/README.md, CHANGELOG.md, CLAUDE.md, TODO.md
- Updates demo page (serve/index.html) including Mermaid diagrams
- Updates repository URLs from yourusername/glossator to cass-clearly/remarq

## Why

"Glossator" is too esoteric. "Remarq" — a blend of remark, mark, and re-mark — better communicates what the tool does.

## Verification

- `grep -ri glossator` returns zero matches (excluding .git/)
- After merge: `gh repo rename remarq`, update remote URL, rename server directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)