### PR TITLE
Center hero section content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -59,14 +59,14 @@
     <!-- Subtle grid overlay -->
     <div class="absolute inset-0 opacity-[0.04]" style="background-image: url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2260%22 height=%2260%22><rect fill=%22none%22 width=%2260%22 height=%2260%22/><path d=%22M0 60L60 0%22 stroke=%22white%22 stroke-width=%220.5%22/></svg>');"></div>
     <div class="relative max-w-6xl mx-auto px-6 py-24 w-full">
-      <div class="max-w-3xl">
+      <div class="max-w-3xl mx-auto text-center">
         <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-white leading-[1.1] mb-6">
           Drop-in <span class="highlight-accent text-white">annotations</span> for any HTML page
         </h1>
-        <p class="text-lg sm:text-xl text-violet-200 mb-10 max-w-2xl leading-relaxed">
+        <p class="text-lg sm:text-xl text-violet-200 mb-10 max-w-2xl mx-auto leading-relaxed">
           Reviewers highlight text and leave threaded comments — no accounts needed. Authors send all feedback to Claude for AI-assisted revision. One script tag. Self-hosted.
         </p>
-        <div class="flex flex-wrap gap-4 mb-14">
+        <div class="flex flex-wrap justify-center gap-4 mb-14">
           <a href="#setup" class="bg-violet-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-violet-500 transition-colors">Get Started</a>
           <a href="https://github.com/cass-clearly/remarq" target="_blank" rel="noopener" class="border border-violet-400/30 text-violet-200 px-6 py-3 rounded-lg font-semibold hover:bg-violet-900/40 transition-colors flex items-center gap-2">
             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -75,7 +75,7 @@
         </div>
 
         <!-- Quick-start terminal -->
-        <div class="bg-gray-900/80 border border-violet-500/20 rounded-xl overflow-hidden max-w-xl">
+        <div class="bg-gray-900/80 border border-violet-500/20 rounded-xl overflow-hidden max-w-xl mx-auto text-left">
           <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
             <span class="w-3 h-3 rounded-full bg-red-500/70"></span>
             <span class="w-3 h-3 rounded-full bg-yellow-500/70"></span>
@@ -94,7 +94,7 @@ npm start">Copy</button>
         </div>
 
         <!-- Embed snippet -->
-        <div class="mt-6 bg-gray-900/80 border border-violet-500/20 rounded-xl overflow-hidden max-w-xl">
+        <div class="mt-6 bg-gray-900/80 border border-violet-500/20 rounded-xl overflow-hidden max-w-xl mx-auto text-left">
           <div class="flex items-center justify-between px-4 py-3 border-b border-gray-800">
             <span class="text-xs text-gray-500 font-mono">Embed in any page</span>
           </div>


### PR DESCRIPTION
## Summary
- Center the hero heading, subheading, CTA buttons, and code blocks horizontally on the marketing page
- Adds `mx-auto`, `text-center`, and `justify-center` to hero container and child elements
- Code blocks get `text-left` to keep terminal content left-aligned within their centered container

## Why
The hero content was left-aligned within the page, which looked off for a landing page. Standard marketing layout centers the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)