### PR TITLE
Revert accidental server package name change

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@csalvato/remarq-server",
+  "name": "remarq-server",
   "version": "1.3.0",
   "description": "Lightweight document annotation server for Remarq",
   "main": "index.js",


### PR DESCRIPTION
## Summary

- Reverts the server package name from `@csalvato/remarq-server` back to `remarq-server`
- This was an uncommitted working tree change that got accidentally included in #21

## Test plan

- [x] No code changes — only the `name` field in `server/package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)