### PR TITLE
Fix placeholder author in feedback-layer package

### DIFF
--- a/feedback-layer/package.json
+++ b/feedback-layer/package.json
@@ -23,7 +23,7 @@
     "text-anchoring",
     "web-annotations"
   ],
-  "author": "Your Name <your.email@example.com>",
+  "author": "Christopher Salvato <csalvato@gmail.com>",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Replaces the placeholder `"author": "Your Name <your.email@example.com>"` with `"author": "Christopher Salvato <csalvato@gmail.com>"` in `feedback-layer/package.json`.

Flagged as a non-blocking nit during the #35 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)