### PR TITLE
Remove TODO.md — migrated to GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Configure via `data-` attributes on the script tag:
 
 ### Docker Compose (recommended)
 
-Create a `.env` file next to `docker-compose.remarq.yml` (docker compose reads it automatically):
+Create a `.env` file:
 
 ```
 POSTGRES_PASSWORD=your-secure-password-here


### PR DESCRIPTION
## Summary

Deletes `TODO.md`. All open items have been migrated to individual GitHub issues (#40–#43, #54–#103). Completed/shipped items (Docker, Postgres, Mermaid) were omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)