### PR TITLE
Add toast notification system, replace alert() dialogs

### DIFF
--- a/feedback-layer/src/index.js
+++ b/feedback-layer/src/index.js
@@ -33,6 +33,7 @@ import {
   getCommenter,
 } from "./sidebar.js";
 import { initAuthorUI } from "./ui.js";
+import { showToast } from "./toast.js";
 
 let _root = null;      // content root element
 let _docUri = null;     // canonical URI for this document
@@ -140,6 +141,7 @@ async function loadComments() {
     renderComments(_comments, _anchoredIds, _commentRanges);
   } catch (err) {
     console.error("[feedback-layer] Failed to load comments:", err);
+    showToast("Failed to load comments", "error");
   }
 }
 
@@ -274,12 +276,13 @@ async function handleCommentSubmit({ comment, commenter }) {
     }
 
     renderComments(_comments, _anchoredIds, _commentRanges);
+    showToast("Comment saved", "success");
 
     // Clear selection
     window.getSelection().removeAllRanges();
   } catch (err) {
     console.error("[feedback-layer] Failed to create comment:", err);
-    alert("Failed to save comment: " + err.message);
+    showToast("Failed to save comment", "error");
   }
 
   _pendingSelector = null;
@@ -311,8 +314,10 @@ async function handleResolve(commentId, resolved) {
     }
 
     renderComments(_comments, _anchoredIds, _commentRanges);
+    showToast(resolved ? "Comment resolved" : "Comment reopened", "success");
   } catch (err) {
     console.error("[feedback-layer] Failed to resolve comment:", err);
+    showToast("Failed to update comment", "error");
   }
 }
 
@@ -327,9 +332,10 @@ async function handleReply({ parent_id, comment, commenter }) {
     });
     _comments.push(reply);
     renderComments(_comments, _anchoredIds, _commentRanges);
+    showToast("Reply saved", "success");
   } catch (err) {
     console.error("[feedback-layer] Failed to create reply:", err);
-    alert("Failed to save reply: " + err.message);
+    showToast("Failed to save reply", "error");
   }
 }
 
@@ -339,9 +345,10 @@ async function handleEdit(commentId, comment) {
     const idx = _comments.findIndex((a) => a.id === commentId);
     if (idx !== -1) _comments[idx] = updated;
     renderComments(_comments, _anchoredIds, _commentRanges);
+    showToast("Comment updated", "success");
   } catch (err) {
     console.error("[feedback-layer] Failed to edit comment:", err);
-    alert("Failed to update comment: " + err.message);
+    showToast("Failed to update comment", "error");
   }
 }
 
@@ -354,8 +361,10 @@ async function handleDelete(commentId) {
       (a) => a.id !== commentId && a.parent !== commentId
     );
     renderComments(_comments, _anchoredIds, _commentRanges);
+    showToast("Comment deleted", "success");
   } catch (err) {
     console.error("[feedback-layer] Failed to delete comment:", err);
+    showToast("Failed to delete comment", "error");
   }
 }
 

--- a/feedback-layer/src/sidebar.js
+++ b/feedback-layer/src/sidebar.js
@@ -11,6 +11,7 @@ import { escapeHtml } from "./utils/escape-html.js";
 import { threadComments } from "./utils/thread-comments.js";
 import { truncate } from "./utils/truncate.js";
 import { timeAgo } from "./utils/time-ago.js";
+import { initToastContainer } from "./toast.js";
 
 const SIDEBAR_WIDTH = 320;
 const COMMENTER_KEY = "feedback-layer-commenter";
@@ -88,6 +89,9 @@ export function createSidebar({ onSubmit, onDelete, onResolve, onReply, onEdit }
   document.body.appendChild(tab);
 
   document.body.appendChild(_sidebar);
+
+  // Toast container (lives inside the sidebar so it scrolls with it)
+  initToastContainer(_sidebar);
 
   _listEl = _sidebar.querySelector(".fb-comment-list");
   _formEl = _sidebar.querySelector(".fb-form-section");
@@ -806,6 +810,57 @@ function injectStyles() {
         opacity: 1;
         transform: translateY(0);
       }
+    }
+
+    /* Toast notifications */
+    .fb-toast-container {
+      position: absolute;
+      bottom: 12px;
+      left: 12px;
+      right: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      pointer-events: none;
+    }
+    .fb-toast {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 10px 14px;
+      border-radius: 8px;
+      font-size: 13px;
+      font-weight: 500;
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      pointer-events: auto;
+      opacity: 0;
+      transform: translateY(100%);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+    .fb-toast-visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    .fb-toast-success {
+      background: #16a34a;
+    }
+    .fb-toast-error {
+      background: #dc2626;
+    }
+    .fb-toast-dismiss {
+      background: none;
+      border: none;
+      color: rgba(255,255,255,0.8);
+      font-size: 18px;
+      cursor: pointer;
+      padding: 0 2px;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+    .fb-toast-dismiss:hover {
+      color: #fff;
     }
   `;
   document.head.appendChild(style);

--- a/feedback-layer/src/toast.js
+++ b/feedback-layer/src/toast.js
@@ -1,0 +1,62 @@
+/**
+ * Toast notification system for the feedback layer.
+ *
+ * Exports:
+ * - initToastContainer(parentEl) — append toast container to sidebar
+ * - showToast(message, type) — display a toast ('success' | 'error')
+ */
+
+let _container = null;
+
+/**
+ * Create and append the toast container inside the given parent element.
+ */
+export function initToastContainer(parentEl) {
+  _container = document.createElement("div");
+  _container.className = "fb-toast-container";
+  parentEl.appendChild(_container);
+}
+
+/**
+ * Show a toast notification.
+ *
+ * @param {string} message - Text to display
+ * @param {'success'|'error'} type - Toast type
+ */
+export function showToast(message, type = "success") {
+  if (!_container) return;
+
+  const toast = document.createElement("div");
+  toast.className = `fb-toast fb-toast-${type}`;
+
+  const text = document.createElement("span");
+  text.textContent = message;
+  toast.appendChild(text);
+
+  if (type === "error") {
+    const dismiss = document.createElement("button");
+    dismiss.className = "fb-toast-dismiss";
+    dismiss.innerHTML = "&times;";
+    dismiss.addEventListener("click", () => removeToast(toast));
+    toast.appendChild(dismiss);
+  }
+
+  _container.appendChild(toast);
+
+  // Trigger slide-up animation on next frame
+  requestAnimationFrame(() => {
+    toast.classList.add("fb-toast-visible");
+  });
+
+  // Auto-dismiss success toasts after 4s
+  if (type === "success") {
+    setTimeout(() => removeToast(toast), 4000);
+  }
+}
+
+function removeToast(toast) {
+  toast.classList.remove("fb-toast-visible");
+  toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+  // Fallback removal if transitionend doesn't fire
+  setTimeout(() => { if (toast.parentNode) toast.remove(); }, 300);
+}


### PR DESCRIPTION
## Summary
- **New `toast.js` module** — lightweight toast component with slide-up animation, auto-dismiss for success (4s), and persistent dismiss button for errors
- **Replaced 3 `alert()` calls** in `handleCommentSubmit`, `handleReply`, and `handleEdit` with non-blocking error toasts
- **Added success toasts** to all 5 mutation handlers (create, reply, edit, resolve, delete) so users get confirmation their action worked
- **Added error toasts** to 3 previously silent failures (`handleResolve`, `handleDelete`, `loadComments`) that only logged to console

## Local testing

```bash
# 1. Check out the branch
git fetch origin
git checkout feature/toast-notifications

# 2. Install dependencies and build the feedback layer
cd feedback-layer
npm install
npm run build

# 3. Start the server (requires PostgreSQL running)
cd ../server
npm install
npm start

# 4. Open the demo page in your browser
open http://localhost:3333
```

Then walk through the test plan below. The sidebar must be open to see toasts (they render inside it).

## Test plan
- [ ] Create a comment — see "Comment saved" toast that auto-dismisses after ~4s
- [ ] Reply to a comment — see "Reply saved" toast
- [ ] Edit a comment — see "Comment updated" toast
- [ ] Resolve a comment — see "Comment resolved" toast
- [ ] Delete a comment — see "Comment deleted" toast
- [ ] Kill the API server, try to create a comment — see error toast with dismiss button (not a browser alert)
- [ ] Verify error toasts persist until manually dismissed
- [ ] Verify multiple toasts stack vertically
- [ ] Run `npm run test:client` — all 30 tests pass

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)