### PR TITLE
Add annotation count badge on highlights

### DIFF
--- a/feedback-layer/src/index.js
+++ b/feedback-layer/src/index.js
@@ -23,7 +23,9 @@ import {
   removeAllHighlights,
   setHighlightClickHandler,
   setActiveHighlight,
+  updateBadges,
 } from "./highlights.js";
+import { getAnnotationCounts } from "./utils/annotation-counts.js";
 import {
   createSidebar,
   showCommentForm,
@@ -43,6 +45,10 @@ let _pendingSelector = null; // selector awaiting comment submission
 let _tooltip = null;    // the "Annotate" tooltip element
 let _anchoredIds = new Set();  // Track successfully anchored comments
 let _commentRanges = new Map();  // Map comment ID to its range for position sorting
+
+function refreshBadges() {
+  updateBadges(getAnnotationCounts(_comments));
+}
 
 function init() {
   const scriptTag =
@@ -139,6 +145,7 @@ async function loadComments() {
     const anchored = await anchorAll(_comments);
     _anchoredIds = anchored;
     renderComments(_comments, _anchoredIds, _commentRanges);
+    refreshBadges();
   } catch (err) {
     console.error("[feedback-layer] Failed to load comments:", err);
     showToast(`Failed to load comments: ${err.message}`, "error");
@@ -276,6 +283,7 @@ async function handleCommentSubmit({ comment, commenter }) {
     }
 
     renderComments(_comments, _anchoredIds, _commentRanges);
+    refreshBadges();
 
     // Clear selection
     window.getSelection().removeAllRanges();
@@ -313,6 +321,7 @@ async function handleResolve(commentId, resolved) {
     }
 
     renderComments(_comments, _anchoredIds, _commentRanges);
+    refreshBadges();
   } catch (err) {
     console.error("[feedback-layer] Failed to resolve comment:", err);
     showToast(`Failed to update comment: ${err.message}`, "error");
@@ -330,6 +339,7 @@ async function handleReply({ parent_id, comment, commenter }) {
     });
     _comments.push(reply);
     renderComments(_comments, _anchoredIds, _commentRanges);
+    refreshBadges();
   } catch (err) {
     console.error("[feedback-layer] Failed to create reply:", err);
     showToast(`Failed to save reply: ${err.message}`, "error");
@@ -342,6 +352,7 @@ async function handleEdit(commentId, comment) {
     const idx = _comments.findIndex((a) => a.id === commentId);
     if (idx !== -1) _comments[idx] = updated;
     renderComments(_comments, _anchoredIds, _commentRanges);
+    refreshBadges();
   } catch (err) {
     console.error("[feedback-layer] Failed to edit comment:", err);
     showToast(`Failed to update comment: ${err.message}`, "error");
@@ -357,6 +368,7 @@ async function handleDelete(commentId) {
       (a) => a.id !== commentId && a.parent !== commentId
     );
     renderComments(_comments, _anchoredIds, _commentRanges);
+    refreshBadges();
   } catch (err) {
     console.error("[feedback-layer] Failed to delete comment:", err);
     showToast(`Failed to delete comment: ${err.message}`, "error");

--- a/feedback-layer/src/sidebar.js
+++ b/feedback-layer/src/sidebar.js
@@ -755,6 +755,33 @@ function injectStyles() {
     }
     .fb-btn-cancel:hover { background: #e5e7eb; }
 
+    /* Annotation count badge on highlights */
+    .fb-badge {
+      position: absolute;
+      top: -8px;
+      right: -8px;
+      min-width: 18px;
+      height: 18px;
+      line-height: 18px;
+      padding: 0 5px;
+      background: #7c3aed;
+      color: #fff;
+      font-size: 11px;
+      font-weight: 700;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      text-align: center;
+      border-radius: 9px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+      cursor: pointer;
+      pointer-events: auto;
+      box-sizing: border-box;
+      z-index: 1;
+    }
+    .fb-badge:hover {
+      background: #6d28d9;
+      transform: scale(1.1);
+    }
+
     /* Annotate tooltip (appears on text selection) */
     .fb-annotate-tooltip {
       position: absolute;

--- a/feedback-layer/src/utils/annotation-counts.js
+++ b/feedback-layer/src/utils/annotation-counts.js
@@ -1,0 +1,21 @@
+/**
+ * Count total annotations (comment + replies) per top-level comment.
+ *
+ * @param {Array} comments - Flat list of all comments
+ * @returns {Map<string, number>} Map of top-level comment ID to total annotation count
+ */
+export function getAnnotationCounts(comments) {
+  const counts = new Map();
+
+  for (const c of comments) {
+    if (!c.parent) {
+      // Top-level comment: initialize with 1
+      counts.set(c.id, (counts.get(c.id) || 0) + 1);
+    } else {
+      // Reply: increment parent's count
+      counts.set(c.parent, (counts.get(c.parent) || 0) + 1);
+    }
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## Summary

Implements #71 — shows a pill-shaped badge on highlights when a comment thread has 2+ annotations (parent comment + replies).

- **New utility** `annotation-counts.js`: pure function `getAnnotationCounts(comments)` returns a `Map<commentId, count>` of total annotations per top-level comment
- **Badge rendering** in `highlights.js`: `updateBadges(counts)` creates/removes badge `<span>` elements positioned absolutely at the top-right of the first `<mark>` for each comment
- **Dynamic updates** in `index.js`: `refreshBadges()` called after every state change (load, create, delete, reply, resolve, edit)
- **Badge styling** in `sidebar.js`: purple pill, 18px height, hover scale effect, matches the app's design language
- **Clicking a badge** opens the sidebar focused on that comment's thread

## Test plan

- [x] New `getAnnotationCounts` tests cover: empty array, single comment, multiple replies, mixed threads, out-of-order replies
- [x] All 36 client tests pass with 100% coverage
- [x] Bundle builds successfully
- [ ] Manual: create a comment, add replies, verify badge appears with correct count
- [ ] Manual: delete a reply, verify badge count decreases (disappears at count=1)
- [ ] Manual: click badge, verify sidebar opens to that thread

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)