### PR TITLE
Add migration guide from other annotation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ For replies, set `parent` to the parent comment's ID. Replies don't need `quote`
 - **One script tag** — drop-in integration for any HTML page
 - **Agent-ready API** — structured feedback your AI can consume and act on
 
+## Migrating from Other Tools
+
+Switching from Hypothesis, Docdrop, or another W3C Web Annotation tool? See the **[Migration Guide](docs/migration.md)** for data model mappings, edge case documentation, and ready-to-run migration scripts.
+
 ## The Bottom Line
 
 Your team's feedback shouldn't rot in a Google Docs sidebar. Build the agent loop. Close the feedback cycle. Ship faster.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,321 @@
+# Migration Guide: Switching to Remarq
+
+This guide covers migrating annotations from other tools to Remarq, including data model mappings, edge cases, and step-by-step workflows.
+
+## Supported Migration Paths
+
+| Source Tool | Support Level | Script Provided |
+|---|---|---|
+| [Hypothesis](https://web.hypothes.is/) | Full | `tools/migrate-hypothesis.js` |
+| [W3C Web Annotation](https://www.w3.org/TR/annotation-model/) | Full | `tools/migrate-w3c-annotation.js` |
+| [Docdrop](https://docdrop.org/) | Via Hypothesis | Use the Hypothesis script (see [Docdrop section](#docdrop)) |
+
+---
+
+## Data Model Mappings
+
+### Hypothesis to Remarq
+
+Hypothesis and Remarq both use the [W3C TextQuoteSelector](https://www.w3.org/TR/annotation-model/#text-quote-selector) for text anchoring, so the core data maps cleanly.
+
+| Hypothesis Field | Remarq Field | Notes |
+|---|---|---|
+| `target[0].selector` (TextQuoteSelector) `.exact` | `quote` | Direct mapping |
+| `target[0].selector` (TextQuoteSelector) `.prefix` | `prefix` | Direct mapping |
+| `target[0].selector` (TextQuoteSelector) `.suffix` | `suffix` | Direct mapping |
+| `text` | `body` | Comment content |
+| `user_info.display_name` | `author` | Falls back to `user` (acct:name@authority) if display name unavailable |
+| `target[0].source` | `uri` | Document URL; Remarq normalizes URIs automatically |
+| `references` | `parent` | Array of ancestor IDs; first element is the root. See [Thread Reconstruction](#thread-reconstruction) |
+| `tags` | _(dropped)_ | No direct equivalent in Remarq. Appended to body if `--include-tags` flag is used |
+| _(none)_ | `status` | Defaults to `"open"`. Hypothesis has no native status concept |
+
+**Example mapping:**
+
+```
+Hypothesis annotation:
+{
+  "id": "abc123",
+  "text": "This paragraph needs a citation.",
+  "user": "acct:alice@hypothes.is",
+  "user_info": { "display_name": "Alice" },
+  "target": [{
+    "source": "https://example.com/paper.html",
+    "selector": [
+      { "type": "TextQuoteSelector", "exact": "climate change accelerates", "prefix": "research shows ", "suffix": " beyond predictions" },
+      { "type": "TextPositionSelector", "start": 1024, "end": 1050 }
+    ]
+  }],
+  "tags": ["needs-citation"],
+  "references": [],
+  "created": "2024-06-15T10:30:00Z"
+}
+
+Remarq comment:
+{
+  "uri": "https://example.com/paper.html",
+  "quote": "climate change accelerates",
+  "prefix": "research shows ",
+  "suffix": " beyond predictions",
+  "body": "This paragraph needs a citation.",
+  "author": "Alice"
+}
+→ Created with status: "open", parent: null
+```
+
+### W3C Web Annotation to Remarq
+
+The [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/) is the standard both Hypothesis and Remarq draw from. Annotations using TextQuoteSelector map directly.
+
+| W3C Field | Remarq Field | Notes |
+|---|---|---|
+| `target.selector` (TextQuoteSelector) `.exact` | `quote` | Direct mapping |
+| `target.selector` (TextQuoteSelector) `.prefix` | `prefix` | Direct mapping |
+| `target.selector` (TextQuoteSelector) `.suffix` | `suffix` | Direct mapping |
+| `body[0].value` or `body.value` | `body` | First body with `type: "TextualBody"` is used |
+| `creator.name` or `creator` | `author` | String or object with `.name` |
+| `target.source` or `target` (if string) | `uri` | Document URL |
+| _(none)_ | `status` | Defaults to `"open"` |
+| _(none)_ | `parent` | W3C model has no native threading; all annotations are root comments |
+
+**Example mapping:**
+
+```
+W3C Web Annotation:
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "type": "Annotation",
+  "body": {
+    "type": "TextualBody",
+    "value": "This section is unclear.",
+    "format": "text/plain"
+  },
+  "target": {
+    "source": "https://example.com/spec.html",
+    "selector": {
+      "type": "TextQuoteSelector",
+      "exact": "the process is deterministic",
+      "prefix": "In all cases, ",
+      "suffix": " and reproducible."
+    }
+  },
+  "creator": { "type": "Person", "name": "Bob" }
+}
+
+Remarq comment:
+{
+  "uri": "https://example.com/spec.html",
+  "quote": "the process is deterministic",
+  "prefix": "In all cases, ",
+  "suffix": " and reproducible.",
+  "body": "This section is unclear.",
+  "author": "Bob"
+}
+→ Created with status: "open", parent: null
+```
+
+### Docdrop
+
+[Docdrop](https://docdrop.org/) is a document hosting service that uses Hypothesis for its annotation layer. Docdrop does not expose its own annotation API or export format.
+
+**To migrate Docdrop annotations**, use the Hypothesis migration script — your Docdrop annotations are stored in Hypothesis and accessible through the Hypothesis API. Use the Docdrop document URL as the `--document-uri` argument.
+
+---
+
+## Edge Cases
+
+### Content Drift
+
+When the annotated text has changed since the annotation was created, annotations may fail to re-anchor on the target document. This is inherent to text-based anchoring — it's not a migration issue, it's a content issue.
+
+**What happens:** The `quote` text no longer exists at the expected location. Remarq stores the annotation with the original `quote`, `prefix`, and `suffix` values. The feedback layer's anchoring logic (via Apache Annotator) will attempt fuzzy matching, but if the text has changed significantly, the highlight won't appear.
+
+**What to do:**
+- After migration, load the target document with Remarq to verify annotations anchor correctly
+- Annotations that don't anchor are still accessible via the API — they just won't have visible highlights
+- Manually review orphaned annotations and update `quote`/`prefix`/`suffix` if needed
+
+### Thread Reconstruction
+
+Hypothesis stores reply chains using a `references` array — each reply contains the IDs of all its ancestors, with the root annotation's ID first.
+
+```
+Root annotation:    { id: "root1", references: [] }
+  Reply to root:    { id: "reply1", references: ["root1"] }
+    Reply to reply: { id: "reply2", references: ["root1", "reply1"] }
+```
+
+Remarq uses a simpler `parent` field pointing to the root comment. The migration script handles this by:
+
+1. Processing annotations sorted by creation time (roots first)
+2. For each reply, mapping `references[0]` (the root annotation) to the corresponding Remarq comment ID
+3. If the root annotation hasn't been migrated yet (e.g., it was deleted), the reply is created as a new root comment with a note in the body
+
+### Status Mapping
+
+Hypothesis has no native concept of "resolved" or "closed" annotations. All migrated annotations default to `status: "open"`.
+
+If you used Hypothesis tags to track resolution (e.g., a `resolved` tag), you can close these after migration:
+
+```bash
+# After migration, close resolved comments via the API
+curl -X PATCH http://localhost:3333/comments/COMMENT_ID \
+  -H "Content-Type: application/json" \
+  -d '{"status": "closed"}'
+```
+
+### Document URI Normalization
+
+Remarq normalizes URIs automatically (lowercases scheme/host, upgrades HTTP to HTTPS, strips tracking params, removes fragments, sorts query params). This means:
+
+- `http://example.com/page?utm_source=twitter#section` and `https://example.com/page` resolve to the **same document**
+- Annotations from different URL variations will be grouped together automatically
+- No manual URI cleanup is needed before migration
+
+---
+
+## Step-by-Step Migration Workflow
+
+### From Hypothesis
+
+**Prerequisites:**
+- A Hypothesis API key ([get one here](https://hypothes.is/account/developer))
+- Your Hypothesis username
+- A running Remarq instance
+
+**Steps:**
+
+#### 1. Export and migrate annotations
+
+```bash
+# Dry run — preview what will be migrated (no data written)
+node tools/migrate-hypothesis.js \
+  --hypothesis-api-key YOUR_API_KEY \
+  --hypothesis-user YOUR_USERNAME \
+  --remarq-url http://localhost:3333 \
+  --document-uri https://example.com/doc.html \
+  --dry-run
+
+# Run the migration
+node tools/migrate-hypothesis.js \
+  --hypothesis-api-key YOUR_API_KEY \
+  --hypothesis-user YOUR_USERNAME \
+  --remarq-url http://localhost:3333 \
+  --document-uri https://example.com/doc.html
+```
+
+**Options:**
+
+| Flag | Required | Description |
+|---|---|---|
+| `--hypothesis-api-key` | Yes | Your Hypothesis developer API key |
+| `--hypothesis-user` | Yes | Your Hypothesis username |
+| `--remarq-url` | Yes | Base URL of your Remarq instance |
+| `--document-uri` | No | Migrate annotations for a specific document only. If omitted, migrates all annotations for the user. |
+| `--dry-run` | No | Preview migration without creating any comments |
+| `--include-tags` | No | Append Hypothesis tags to comment body (e.g., `[tags: review, important]`) |
+
+#### 2. Verify annotations
+
+Load the target document with the Remarq script tag and confirm annotations appear correctly. Check the API for any annotations that didn't anchor:
+
+```bash
+curl "http://localhost:3333/comments?uri=https://example.com/doc.html" | jq '.data | length'
+```
+
+#### 3. Review migration errors
+
+If any annotations failed to migrate, the script writes details to `migration-errors.json` in the working directory:
+
+```json
+[
+  {
+    "hypothesisId": "abc123",
+    "error": "Request failed: 400 Bad Request",
+    "annotation": { "text": "...", "uri": "..." }
+  }
+]
+```
+
+### From W3C Web Annotation JSON
+
+**Prerequisites:**
+- A JSON file containing W3C Web Annotation format annotations (single annotation or array)
+- A running Remarq instance
+
+**Steps:**
+
+#### 1. Export annotations from your source tool
+
+Most W3C-compliant annotation tools provide a JSON export. Save it to a file.
+
+#### 2. Run the migration
+
+```bash
+# Dry run
+node tools/migrate-w3c-annotation.js \
+  --input annotations.json \
+  --remarq-url http://localhost:3333 \
+  --dry-run
+
+# Run the migration
+node tools/migrate-w3c-annotation.js \
+  --input annotations.json \
+  --remarq-url http://localhost:3333
+```
+
+**Options:**
+
+| Flag | Required | Description |
+|---|---|---|
+| `--input` | Yes | Path to JSON file with W3C Web Annotation data |
+| `--remarq-url` | Yes | Base URL of your Remarq instance |
+| `--dry-run` | No | Preview migration without creating any comments |
+
+#### 3. Verify and review
+
+Same as the Hypothesis workflow — load documents, check anchoring, review `migration-errors.json`.
+
+### From Docdrop
+
+Use the Hypothesis migration workflow. Your Docdrop annotations are stored in Hypothesis, so you just need your Hypothesis API key and the document URI from Docdrop.
+
+```bash
+node tools/migrate-hypothesis.js \
+  --hypothesis-api-key YOUR_API_KEY \
+  --hypothesis-user YOUR_USERNAME \
+  --remarq-url http://localhost:3333 \
+  --document-uri https://docdrop.org/video/VIDEO_ID
+```
+
+---
+
+## Programmatic Migration
+
+If you need to migrate from a tool not listed here, the Remarq API is straightforward. Here's the minimum you need:
+
+```bash
+# Create a comment
+curl -X POST http://localhost:3333/comments \
+  -H "Content-Type: application/json" \
+  -d '{
+    "uri": "https://example.com/page.html",
+    "quote": "exact text that was highlighted",
+    "prefix": "text before the highlight",
+    "suffix": "text after the highlight",
+    "body": "Your comment here",
+    "author": "Commenter Name"
+  }'
+
+# Create a reply
+curl -X POST http://localhost:3333/comments \
+  -H "Content-Type: application/json" \
+  -d '{
+    "body": "Reply text",
+    "author": "Another Person",
+    "parent": "cmt_PARENT_ID",
+    "uri": "https://example.com/page.html"
+  }'
+```
+
+See the [API Reference](../README.md#api-reference) for the full specification.

--- a/tools/migrate-hypothesis.js
+++ b/tools/migrate-hypothesis.js
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const { parseArgs } = require('node:util');
+const fs = require('node:fs');
+
+const HYPOTHESIS_API = 'https://api.hypothes.is/api';
+const HYPOTHESIS_PAGE_SIZE = 200; // max per request
+
+function parseCliArgs() {
+  const { values } = parseArgs({
+    options: {
+      'hypothesis-api-key': { type: 'string' },
+      'hypothesis-user': { type: 'string' },
+      'remarq-url': { type: 'string' },
+      'document-uri': { type: 'string' },
+      'dry-run': { type: 'boolean', default: false },
+      'include-tags': { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help) {
+    console.log(`Usage: node migrate-hypothesis.js [options]
+
+Options:
+  --hypothesis-api-key  Your Hypothesis developer API key (required)
+  --hypothesis-user     Your Hypothesis username (required)
+  --remarq-url          Base URL of your Remarq instance (required)
+  --document-uri        Migrate only annotations for this document URL
+  --dry-run             Preview migration without writing data
+  --include-tags        Append Hypothesis tags to comment body
+  --help                Show this help message`);
+    process.exit(0);
+  }
+
+  const missing = [];
+  if (!values['hypothesis-api-key']) missing.push('--hypothesis-api-key');
+  if (!values['hypothesis-user']) missing.push('--hypothesis-user');
+  if (!values['remarq-url']) missing.push('--remarq-url');
+
+  if (missing.length > 0) {
+    console.error(`Error: missing required arguments: ${missing.join(', ')}`);
+    console.error('Run with --help for usage information.');
+    process.exit(1);
+  }
+
+  return values;
+}
+
+async function fetchHypothesisAnnotations(apiKey, user, documentUri) {
+  const annotations = [];
+  let offset = 0;
+
+  while (true) {
+    const params = new URLSearchParams({
+      user: `acct:${user}@hypothes.is`,
+      limit: String(HYPOTHESIS_PAGE_SIZE),
+      offset: String(offset),
+      sort: 'created',
+      order: 'asc',
+    });
+
+    if (documentUri) {
+      params.set('uri', documentUri);
+    }
+
+    const url = `${HYPOTHESIS_API}/search?${params}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Hypothesis API error ${res.status}: ${text}`);
+    }
+
+    const data = await res.json();
+    annotations.push(...data.rows);
+
+    if (data.rows.length < HYPOTHESIS_PAGE_SIZE) break;
+    offset += HYPOTHESIS_PAGE_SIZE;
+  }
+
+  return annotations;
+}
+
+function extractTextQuoteSelector(annotation) {
+  if (!annotation.target || annotation.target.length === 0) return null;
+
+  for (const target of annotation.target) {
+    if (!target.selector) continue;
+    const tqs = target.selector.find((s) => s.type === 'TextQuoteSelector');
+    if (tqs) return tqs;
+  }
+
+  return null;
+}
+
+function getAuthor(annotation) {
+  if (annotation.user_info && annotation.user_info.display_name) {
+    return annotation.user_info.display_name;
+  }
+  // Extract username from acct:username@authority format
+  const match = annotation.user && annotation.user.match(/^acct:([^@]+)@/);
+  return match ? match[1] : annotation.user || 'Unknown';
+}
+
+function getDocumentUri(annotation) {
+  if (annotation.target && annotation.target.length > 0 && annotation.target[0].source) {
+    return annotation.target[0].source;
+  }
+  return annotation.uri || null;
+}
+
+function buildCommentBody(annotation, includeTags) {
+  let body = annotation.text || '';
+  if (includeTags && annotation.tags && annotation.tags.length > 0) {
+    body += `\n[tags: ${annotation.tags.join(', ')}]`;
+  }
+  return body;
+}
+
+function isReply(annotation) {
+  return annotation.references && annotation.references.length > 0;
+}
+
+async function createRemarqComment(remarqUrl, comment) {
+  const res = await fetch(`${remarqUrl}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(comment),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Remarq API error ${res.status}: ${text}`);
+  }
+
+  return res.json();
+}
+
+async function migrate(args) {
+  const apiKey = args['hypothesis-api-key'];
+  const user = args['hypothesis-user'];
+  const remarqUrl = args['remarq-url'].replace(/\/+$/, '');
+  const documentUri = args['document-uri'] || null;
+  const dryRun = args['dry-run'];
+  const includeTags = args['include-tags'];
+
+  console.log(`Fetching annotations from Hypothesis for user "${user}"...`);
+  if (documentUri) console.log(`  Filtering by document: ${documentUri}`);
+
+  const annotations = await fetchHypothesisAnnotations(apiKey, user, documentUri);
+  console.log(`Found ${annotations.length} annotations.`);
+
+  if (annotations.length === 0) {
+    console.log('Nothing to migrate.');
+    return;
+  }
+
+  // Separate roots and replies, process roots first
+  const roots = annotations.filter((a) => !isReply(a));
+  const replies = annotations.filter((a) => isReply(a));
+
+  // Map from Hypothesis ID to Remarq ID
+  const idMap = {};
+  const errors = [];
+  let migratedCount = 0;
+  const total = annotations.length;
+
+  // Process root annotations
+  for (const annot of roots) {
+    const selector = extractTextQuoteSelector(annot);
+    const body = buildCommentBody(annot, includeTags);
+
+    if (!body.trim()) {
+      console.log(`  Skipping ${annot.id} — empty body`);
+      continue;
+    }
+
+    const uri = getDocumentUri(annot);
+    if (!uri) {
+      console.log(`  Skipping ${annot.id} — no document URI`);
+      continue;
+    }
+
+    const comment = {
+      uri,
+      quote: selector ? selector.exact || '' : '',
+      prefix: selector ? selector.prefix || '' : '',
+      suffix: selector ? selector.suffix || '' : '',
+      body,
+      author: getAuthor(annot),
+    };
+
+    migratedCount++;
+
+    if (dryRun) {
+      console.log(`  [${migratedCount}/${total}] (dry-run) Would create root comment: "${body.slice(0, 60)}..." on ${uri}`);
+      idMap[annot.id] = `dry-run-${annot.id}`;
+      continue;
+    }
+
+    try {
+      const created = await createRemarqComment(remarqUrl, comment);
+      idMap[annot.id] = created.id;
+      console.log(`  [${migratedCount}/${total}] Migrated root: ${created.id}`);
+    } catch (err) {
+      console.error(`  [${migratedCount}/${total}] Failed root ${annot.id}: ${err.message}`);
+      errors.push({ hypothesisId: annot.id, error: err.message, annotation: { text: annot.text, uri } });
+    }
+  }
+
+  // Process replies
+  for (const annot of replies) {
+    const body = buildCommentBody(annot, includeTags);
+
+    if (!body.trim()) {
+      console.log(`  Skipping reply ${annot.id} — empty body`);
+      continue;
+    }
+
+    const uri = getDocumentUri(annot);
+    if (!uri) {
+      console.log(`  Skipping reply ${annot.id} — no document URI`);
+      continue;
+    }
+
+    // references[0] is the root annotation
+    const rootHypothesisId = annot.references[0];
+    const remarqParentId = idMap[rootHypothesisId];
+
+    const comment = { uri, body, author: getAuthor(annot) };
+
+    if (remarqParentId) {
+      comment.parent = remarqParentId;
+    } else {
+      // Root wasn't migrated (deleted, or from another user) — create as root with note
+      const selector = extractTextQuoteSelector(annot);
+      comment.quote = selector ? selector.exact || '' : '';
+      comment.prefix = selector ? selector.prefix || '' : '';
+      comment.suffix = selector ? selector.suffix || '' : '';
+      comment.body = `[Orphaned reply — original thread not found]\n\n${body}`;
+    }
+
+    migratedCount++;
+
+    if (dryRun) {
+      const type = remarqParentId ? 'reply' : 'orphaned root';
+      console.log(`  [${migratedCount}/${total}] (dry-run) Would create ${type}: "${body.slice(0, 60)}..."`);
+      idMap[annot.id] = `dry-run-${annot.id}`;
+      continue;
+    }
+
+    try {
+      const created = await createRemarqComment(remarqUrl, comment);
+      idMap[annot.id] = created.id;
+      const type = remarqParentId ? 'reply' : 'orphaned root';
+      console.log(`  [${migratedCount}/${total}] Migrated ${type}: ${created.id}`);
+    } catch (err) {
+      console.error(`  [${migratedCount}/${total}] Failed reply ${annot.id}: ${err.message}`);
+      errors.push({ hypothesisId: annot.id, error: err.message, annotation: { text: annot.text, uri } });
+    }
+  }
+
+  // Summary
+  console.log('\n--- Migration Summary ---');
+  console.log(`Total annotations found: ${total}`);
+  console.log(`Successfully migrated: ${migratedCount - errors.length}`);
+  if (errors.length > 0) console.log(`Failed: ${errors.length}`);
+  if (dryRun) console.log('(dry-run mode — no data was written)');
+
+  // Write errors to file
+  if (errors.length > 0 && !dryRun) {
+    const errorFile = 'migration-errors.json';
+    fs.writeFileSync(errorFile, JSON.stringify(errors, null, 2));
+    console.log(`\nError details written to ${errorFile}`);
+  }
+}
+
+migrate(parseCliArgs()).catch((err) => {
+  console.error(`\nFatal error: ${err.message}`);
+  process.exit(1);
+});

--- a/tools/migrate-w3c-annotation.js
+++ b/tools/migrate-w3c-annotation.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const { parseArgs } = require('node:util');
+const fs = require('node:fs');
+
+function parseCliArgs() {
+  const { values } = parseArgs({
+    options: {
+      input: { type: 'string' },
+      'remarq-url': { type: 'string' },
+      'dry-run': { type: 'boolean', default: false },
+      help: { type: 'boolean', default: false },
+    },
+  });
+
+  if (values.help) {
+    console.log(`Usage: node migrate-w3c-annotation.js [options]
+
+Options:
+  --input       Path to JSON file with W3C Web Annotation data (required)
+  --remarq-url  Base URL of your Remarq instance (required)
+  --dry-run     Preview migration without writing data
+  --help        Show this help message`);
+    process.exit(0);
+  }
+
+  const missing = [];
+  if (!values.input) missing.push('--input');
+  if (!values['remarq-url']) missing.push('--remarq-url');
+
+  if (missing.length > 0) {
+    console.error(`Error: missing required arguments: ${missing.join(', ')}`);
+    console.error('Run with --help for usage information.');
+    process.exit(1);
+  }
+
+  return values;
+}
+
+function loadAnnotations(inputPath) {
+  const raw = fs.readFileSync(inputPath, 'utf-8');
+  const data = JSON.parse(raw);
+
+  // Handle single annotation, array, or AnnotationCollection
+  if (Array.isArray(data)) return data;
+  if (data.type === 'AnnotationCollection' || data.type === 'AnnotationPage') {
+    return data.items || data.first?.items || [];
+  }
+  // Single annotation object
+  return [data];
+}
+
+function extractBody(annotation) {
+  const body = annotation.body;
+  if (!body) return '';
+
+  // body can be a string, object, or array
+  if (typeof body === 'string') return body;
+
+  if (Array.isArray(body)) {
+    const textual = body.find((b) => b.type === 'TextualBody') || body[0];
+    return textual?.value || '';
+  }
+
+  return body.value || '';
+}
+
+function extractAuthor(annotation) {
+  const creator = annotation.creator;
+  if (!creator) return 'Unknown';
+  if (typeof creator === 'string') return creator;
+  return creator.name || creator.nickname || 'Unknown';
+}
+
+function extractTarget(annotation) {
+  const target = annotation.target;
+  if (!target) return { uri: null, selector: null };
+
+  // target can be a string, object, or array
+  if (typeof target === 'string') return { uri: target, selector: null };
+
+  const targetObj = Array.isArray(target) ? target[0] : target;
+  const uri = targetObj.source || (typeof targetObj === 'string' ? targetObj : null);
+
+  // Find TextQuoteSelector
+  let selector = null;
+  if (targetObj.selector) {
+    if (Array.isArray(targetObj.selector)) {
+      selector = targetObj.selector.find((s) => s.type === 'TextQuoteSelector') || null;
+    } else if (targetObj.selector.type === 'TextQuoteSelector') {
+      selector = targetObj.selector;
+    }
+  }
+
+  return { uri, selector };
+}
+
+async function createRemarqComment(remarqUrl, comment) {
+  const res = await fetch(`${remarqUrl}/comments`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(comment),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Remarq API error ${res.status}: ${text}`);
+  }
+
+  return res.json();
+}
+
+async function migrate(args) {
+  const remarqUrl = args['remarq-url'].replace(/\/+$/, '');
+  const dryRun = args['dry-run'];
+
+  console.log(`Loading annotations from ${args.input}...`);
+  const annotations = loadAnnotations(args.input);
+  console.log(`Found ${annotations.length} annotations.`);
+
+  if (annotations.length === 0) {
+    console.log('Nothing to migrate.');
+    return;
+  }
+
+  const errors = [];
+  let migratedCount = 0;
+  const total = annotations.length;
+
+  for (const annot of annotations) {
+    const body = extractBody(annot);
+
+    if (!body.trim()) {
+      console.log(`  Skipping annotation — empty body`);
+      continue;
+    }
+
+    const { uri, selector } = extractTarget(annot);
+    if (!uri) {
+      console.log(`  Skipping annotation — no target URI`);
+      continue;
+    }
+
+    const comment = {
+      uri,
+      quote: selector ? selector.exact || '' : '',
+      prefix: selector ? selector.prefix || '' : '',
+      suffix: selector ? selector.suffix || '' : '',
+      body,
+      author: extractAuthor(annot),
+    };
+
+    migratedCount++;
+
+    if (dryRun) {
+      console.log(`  [${migratedCount}/${total}] (dry-run) Would create comment: "${body.slice(0, 60)}..." on ${uri}`);
+      continue;
+    }
+
+    try {
+      const created = await createRemarqComment(remarqUrl, comment);
+      console.log(`  [${migratedCount}/${total}] Migrated: ${created.id}`);
+    } catch (err) {
+      console.error(`  [${migratedCount}/${total}] Failed: ${err.message}`);
+      errors.push({ error: err.message, annotation: { body: body.slice(0, 200), uri } });
+    }
+  }
+
+  // Summary
+  console.log('\n--- Migration Summary ---');
+  console.log(`Total annotations found: ${total}`);
+  console.log(`Successfully migrated: ${migratedCount - errors.length}`);
+  if (errors.length > 0) console.log(`Failed: ${errors.length}`);
+  if (dryRun) console.log('(dry-run mode — no data was written)');
+
+  // Write errors to file
+  if (errors.length > 0 && !dryRun) {
+    const errorFile = 'migration-errors.json';
+    fs.writeFileSync(errorFile, JSON.stringify(errors, null, 2));
+    console.log(`\nError details written to ${errorFile}`);
+  }
+}
+
+migrate(parseCliArgs()).catch((err) => {
+  console.error(`\nFatal error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `docs/migration.md` — comprehensive migration guide covering Hypothesis, W3C Web Annotation, and Docdrop
- Adds `tools/migrate-hypothesis.js` — CLI script to migrate annotations from Hypothesis to Remarq
- Adds `tools/migrate-w3c-annotation.js` — CLI script to migrate W3C Web Annotation JSON files to Remarq
- Updates `README.md` with a "Migrating from Other Tools" section linking to the guide

### What's in the migration guide

- **Data model mappings** — field-by-field mapping tables for Hypothesis → Remarq and W3C → Remarq, with annotated examples
- **Edge cases** — content drift, thread reconstruction, status mapping, URI normalization
- **Step-by-step workflows** — export → run script → verify → review errors
- **Docdrop** — documented that Docdrop uses Hypothesis under the hood; use the Hypothesis script
- **Programmatic migration** — curl examples for custom migrations from unlisted tools

### What the scripts do

- Fetch annotations from source (Hypothesis API or JSON file)
- Map data model fields to Remarq's comment format
- Reconstruct reply threads (Hypothesis `references[]` → Remarq `parent`)
- Handle orphaned replies (root deleted/missing) by creating as root with note
- Dry-run mode, progress logging, error output to `migration-errors.json`
- `--include-tags` flag for Hypothesis to append tags to comment body

Closes #89

## Test plan

- [ ] Run `node tools/migrate-hypothesis.js --help` and `node tools/migrate-w3c-annotation.js --help` — verify help output
- [ ] Run Hypothesis script with `--dry-run` against a test Hypothesis account
- [ ] Create a test W3C annotation JSON file, run W3C script with `--dry-run`
- [ ] Verify migration guide renders correctly on GitHub
- [ ] Verify README link to migration guide works

🤖 Generated with [Claude Code](https://claude.com/claude-code)