### PR TITLE
Add search/filter annotations by keyword and author (#62)

### DIFF
--- a/feedback-layer/src/api.js
+++ b/feedback-layer/src/api.js
@@ -21,11 +21,13 @@ async function throwIfNotOk(res, fallbackMessage) {
   throw new Error(err.error?.message || `${fallbackMessage}: ${res.status}`);
 }
 
-export async function fetchComments(uri, documentId) {
-  const query = documentId
-    ? `document=${encodeURIComponent(documentId)}`
-    : `uri=${encodeURIComponent(uri)}`;
-  const res = await fetch(`${_baseUrl}/comments?${query}`);
+export async function fetchComments(uri, documentId, { search, author } = {}) {
+  const parts = [];
+  if (documentId) parts.push(`document=${encodeURIComponent(documentId)}`);
+  else if (uri) parts.push(`uri=${encodeURIComponent(uri)}`);
+  if (search) parts.push(`search=${encodeURIComponent(search)}`);
+  if (author) parts.push(`author=${encodeURIComponent(author)}`);
+  const res = await fetch(`${_baseUrl}/comments?${parts.join('&')}`);
   await throwIfNotOk(res, "Failed to fetch comments");
   const json = await res.json();
   return json.data;

--- a/feedback-layer/src/highlights.js
+++ b/feedback-layer/src/highlights.js
@@ -329,6 +329,31 @@ export function setHighlightResolved(commentId, resolved) {
 }
 
 /**
+ * Dim highlights for non-matching comments during search/filter.
+ * Pass an empty set to restore all highlights to normal.
+ */
+export function setDimmedHighlights(dimmedIds) {
+  const dimmedColor = "rgba(255, 212, 0, 0.12)";
+  const normalColor = "rgba(255, 212, 0, 0.35)";
+
+  document.querySelectorAll(`.${HIGHLIGHT_CLASS}`).forEach((el) => {
+    const commentId = el.dataset.commentId;
+    const isDimmed = dimmedIds.has(commentId);
+
+    if (el.classList.contains(ACTIVE_CLASS)) return; // Don't dim active highlight
+
+    if (el.tagName === 'g' || el instanceof SVGElement) {
+      const rects = el.querySelectorAll('rect');
+      rects.forEach(rect => {
+        rect.setAttribute('fill-opacity', isDimmed ? '0.12' : '0.35');
+      });
+    } else {
+      el.style.backgroundColor = isDimmed ? dimmedColor : normalColor;
+    }
+  });
+}
+
+/**
  * Collect all text nodes within a Range.
  */
 function getTextNodesInRange(range) {

--- a/feedback-layer/src/index.js
+++ b/feedback-layer/src/index.js
@@ -23,6 +23,7 @@ import {
   removeAllHighlights,
   setHighlightClickHandler,
   setActiveHighlight,
+  setDimmedHighlights,
 } from "./highlights.js";
 import {
   createSidebar,
@@ -31,6 +32,7 @@ import {
   focusCommentCard,
   openSidebar,
   getCommenter,
+  setAuthors,
 } from "./sidebar.js";
 import { initAuthorUI } from "./ui.js";
 import { showToast } from "./toast.js";
@@ -43,6 +45,7 @@ let _pendingSelector = null; // selector awaiting comment submission
 let _tooltip = null;    // the "Annotate" tooltip element
 let _anchoredIds = new Set();  // Track successfully anchored comments
 let _commentRanges = new Map();  // Map comment ID to its range for position sorting
+let _matchedIds = null;  // Set of IDs matching active search, or null if no search
 
 function init() {
   const scriptTag =
@@ -101,6 +104,7 @@ function init() {
         onResolve: handleResolve,
         onReply: handleReply,
         onEdit: handleEdit,
+        onSearch: handleSearch,
       });
 
       // Highlight click → scroll sidebar to card
@@ -138,11 +142,17 @@ async function loadComments() {
     _comments = await fetchComments(_docUri, _docId);
     const anchored = await anchorAll(_comments);
     _anchoredIds = anchored;
-    renderComments(_comments, _anchoredIds, _commentRanges);
+    updateAuthors();
+    renderComments(_comments, _anchoredIds, _commentRanges, _matchedIds);
   } catch (err) {
     console.error("[feedback-layer] Failed to load comments:", err);
     showToast(`Failed to load comments: ${err.message}`, "error");
   }
+}
+
+function updateAuthors() {
+  const authors = [...new Set(_comments.map(c => c.author))];
+  setAuthors(authors);
 }
 
 async function anchorAll(comments) {
@@ -249,6 +259,31 @@ function removeTooltip() {
   }
 }
 
+async function handleSearch(search, author) {
+  if (!search && !author) {
+    _matchedIds = null;
+    renderComments(_comments, _anchoredIds, _commentRanges, null);
+    setDimmedHighlights(new Set());
+    return;
+  }
+
+  try {
+    const filtered = await fetchComments(_docUri, _docId, { search, author });
+    _matchedIds = new Set(filtered.map(c => c.id));
+    renderComments(_comments, _anchoredIds, _commentRanges, _matchedIds);
+
+    const dimmedIds = new Set();
+    for (const c of _comments) {
+      if (!c.parent && _anchoredIds.has(c.id) && !_matchedIds.has(c.id)) {
+        dimmedIds.add(c.id);
+      }
+    }
+    setDimmedHighlights(dimmedIds);
+  } catch (err) {
+    console.error("[feedback-layer] Search failed:", err);
+  }
+}
+
 async function handleCommentSubmit({ comment, commenter }) {
   if (!_pendingSelector) return;
 
@@ -275,7 +310,8 @@ async function handleCommentSubmit({ comment, commenter }) {
       _anchoredIds.add(ann.id);
     }
 
-    renderComments(_comments, _anchoredIds, _commentRanges);
+    updateAuthors();
+    renderComments(_comments, _anchoredIds, _commentRanges, _matchedIds);
 
     // Clear selection
     window.getSelection().removeAllRanges();
@@ -312,7 +348,7 @@ async function handleResolve(commentId, resolved) {
       }
     }
 
-    renderComments(_comments, _anchoredIds, _commentRanges);
+    renderComments(_comments, _anchoredIds, _commentRanges, _matchedIds);
   } catch (err) {
     console.error("[feedback-layer] Failed to resolve comment:", err);
     showToast(`Failed to update comment: ${err.message}`, "error");
@@ -329,7 +365,8 @@ async function handleReply({ parent_id, comment, commenter }) {
       parent: parent_id,
     });
     _comments.push(reply);
-    renderComments(_comments, _anchoredIds, _commentRanges);
+    updateAuthors();
+    renderComments(_comments, _anchoredIds, _commentRanges, _matchedIds);
   } catch (err) {
     console.error("[feedback-layer] Failed to create reply:", err);
     showToast(`Failed to save reply: ${err.message}`, "error");
@@ -341,7 +378,7 @@ async function handleEdit(commentId, comment) {
     const updated = await updateComment(commentId, { body: comment });
     const idx = _comments.findIndex((a) => a.id === commentId);
     if (idx !== -1) _comments[idx] = updated;
-    renderComments(_comments, _anchoredIds, _commentRanges);
+    renderComments(_comments, _anchoredIds, _commentRanges, _matchedIds);
   } catch (err) {
     console.error("[feedback-layer] Failed to edit comment:", err);
     showToast(`Failed to update comment: ${err.message}`, "error");
@@ -356,7 +393,8 @@ async function handleDelete(commentId) {
     _comments = _comments.filter(
       (a) => a.id !== commentId && a.parent !== commentId
     );
-    renderComments(_comments, _anchoredIds, _commentRanges);
+    updateAuthors();
+    renderComments(_comments, _anchoredIds, _commentRanges, _matchedIds);
   } catch (err) {
     console.error("[feedback-layer] Failed to delete comment:", err);
     showToast(`Failed to delete comment: ${err.message}`, "error");

--- a/feedback-layer/src/utils/debounce.js
+++ b/feedback-layer/src/utils/debounce.js
@@ -1,0 +1,7 @@
+export function debounce(fn, ms) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+}

--- a/feedback-layer/test/test.mjs
+++ b/feedback-layer/test/test.mjs
@@ -225,6 +225,41 @@ describe("timeAgo", async () => {
   });
 });
 
+// ── debounce ──────────────────────────────────────────────────────────
+
+describe("debounce", async () => {
+  const { debounce } = await import("../src/utils/debounce.js");
+
+  it("delays function execution", async () => {
+    let called = 0;
+    const fn = debounce(() => called++, 50);
+    fn();
+    assert.equal(called, 0);
+    await new Promise(r => setTimeout(r, 80));
+    assert.equal(called, 1);
+  });
+
+  it("resets timer on subsequent calls", async () => {
+    let called = 0;
+    const fn = debounce(() => called++, 50);
+    fn();
+    await new Promise(r => setTimeout(r, 30));
+    fn(); // reset timer
+    await new Promise(r => setTimeout(r, 30));
+    assert.equal(called, 0); // still waiting
+    await new Promise(r => setTimeout(r, 40));
+    assert.equal(called, 1); // fired once
+  });
+
+  it("passes arguments to the debounced function", async () => {
+    let result;
+    const fn = debounce((a, b) => { result = a + b; }, 50);
+    fn(2, 3);
+    await new Promise(r => setTimeout(r, 80));
+    assert.equal(result, 5);
+  });
+});
+
 // ── api (setBaseUrl only — no fetch mocks) ────────────────────────────
 
 describe("api", async () => {

--- a/server/index.js
+++ b/server/index.js
@@ -162,7 +162,7 @@ app.delete("/documents/:id", asyncHandler(async (req, res) => {
 // ── Comment endpoints ───────────────────────────────────────────────
 
 app.get("/comments", asyncHandler(async (req, res) => {
-  const { document: docId, uri, status, expand } = req.query;
+  const { document: docId, uri, status, expand, search, author } = req.query;
 
   if (status !== undefined && status !== "open" && status !== "closed") {
     return res.status(400).json(errorResponse('status must be "open" or "closed"'));
@@ -180,35 +180,43 @@ app.get("/comments", asyncHandler(async (req, res) => {
     resolvedDocId = docResult.rows[0].id;
   }
 
-  let rows;
+  // Build WHERE conditions dynamically
+  const conditions = [];
+  const params = [];
+  let idx = 1;
+
   if (resolvedDocId) {
-    if (status) {
-      ({ rows } = await pool.query(
-        `SELECT * FROM comments WHERE document = $1
-          AND ((parent IS NULL AND status = $2)
-            OR (parent IN (SELECT id FROM comments WHERE document = $1 AND parent IS NULL AND status = $2)))
-          ORDER BY created_at ASC`,
-        [resolvedDocId, status]
-      ));
-    } else {
-      ({ rows } = await pool.query(
-        "SELECT * FROM comments WHERE document = $1 ORDER BY created_at ASC",
-        [resolvedDocId]
-      ));
-    }
-  } else {
-    if (status) {
-      ({ rows } = await pool.query(
-        `SELECT * FROM comments
-          WHERE (parent IS NULL AND status = $1)
-            OR (parent IN (SELECT id FROM comments WHERE parent IS NULL AND status = $1))
-          ORDER BY created_at ASC`,
-        [status]
-      ));
-    } else {
-      ({ rows } = await pool.query("SELECT * FROM comments ORDER BY created_at ASC"));
-    }
+    conditions.push(`document = $${idx++}`);
+    params.push(resolvedDocId);
   }
+
+  if (status) {
+    const docCond = resolvedDocId ? `document = $1 AND ` : '';
+    conditions.push(
+      `((parent IS NULL AND status = $${idx})` +
+      ` OR (parent IN (SELECT id FROM comments WHERE ${docCond}parent IS NULL AND status = $${idx})))`
+    );
+    params.push(status);
+    idx++;
+  }
+
+  if (search) {
+    conditions.push(`(body ILIKE $${idx} OR quote ILIKE $${idx})`);
+    params.push(`%${search}%`);
+    idx++;
+  }
+
+  if (author) {
+    conditions.push(`author ILIKE $${idx}`);
+    params.push(author);
+    idx++;
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const { rows } = await pool.query(
+    `SELECT * FROM comments ${where} ORDER BY created_at ASC`,
+    params
+  );
 
   let data = rows.map(formatComment);
 


### PR DESCRIPTION
## Summary

- **Server**: Added `?search=<keyword>` and `?author=<name>` query parameters to `GET /comments`. Uses PostgreSQL `ILIKE` for case-insensitive matching on `body`/`quote` fields (search) and `author` field. Refactored the query builder to dynamically compose WHERE conditions, keeping full backward compatibility with existing `document`, `uri`, `status`, and `expand` parameters.
- **Client**: Added search text input and author filter dropdown to the sidebar filter section. Search input is debounced (300ms) and triggers a server re-fetch. Non-matching annotation threads are dimmed (opacity 0.35) in the sidebar, and non-matching document highlights fade to a lighter color (opacity 0.12).
- **Tests**: Added 8 server integration tests covering keyword search (body/quote), case-insensitivity, author filtering, combined filters, and empty results. Added 3 client unit tests for the new debounce utility. All 85 server tests and 33 client tests pass with coverage above threshold.

Closes #62

## Test plan
- [ ] Run `DATABASE_URL="postgres://remarq:remarq@localhost:5433/remarq" npm run test:server` — all 85 tests pass
- [ ] Run `npm run test:client` — all 33 tests pass
- [ ] Load a document with multiple comments by different authors
- [ ] Type in the search box — verify debounced re-fetch dims non-matching threads and fades highlights
- [ ] Select an author from the dropdown — verify only that author's comments are highlighted
- [ ] Combine search + author filter — verify AND behavior
- [ ] Clear both filters — verify all comments and highlights restore to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)