### PR TITLE
Add private vs. public annotations (#60)

### DIFF
--- a/feedback-layer/src/highlights.js
+++ b/feedback-layer/src/highlights.js
@@ -8,6 +8,7 @@
 const HIGHLIGHT_CLASS = "fb-highlight";
 const ACTIVE_CLASS = "fb-highlight-active";
 const RESOLVED_CLASS = "fb-highlight-resolved";
+const PRIVATE_CLASS = "fb-highlight-private";
 
 let _onHighlightClick = null;
 
@@ -19,7 +20,7 @@ export function setHighlightClickHandler(fn) {
  * Wrap a Range in <mark> elements. Returns an array of the created marks
  * (may be multiple if the range spans multiple text nodes).
  */
-export function highlightRange(range, commentId) {
+export function highlightRange(range, commentId, { isPrivate } = {}) {
   const marks = [];
 
   // If the range is within a single text node, simple wrap
@@ -27,7 +28,7 @@ export function highlightRange(range, commentId) {
     range.startContainer === range.endContainer &&
     range.startContainer.nodeType === Node.TEXT_NODE
   ) {
-    const mark = wrapTextRange(range, commentId);
+    const mark = wrapTextRange(range, commentId, isPrivate);
     marks.push(mark);
   } else {
     // Complex range spanning multiple nodes — collect text nodes in range
@@ -47,7 +48,7 @@ export function highlightRange(range, commentId) {
       }
 
       if (!nodeRange.collapsed) {
-        marks.push(wrapTextRange(nodeRange, commentId));
+        marks.push(wrapTextRange(nodeRange, commentId, isPrivate));
       }
     }
   }
@@ -55,7 +56,7 @@ export function highlightRange(range, commentId) {
   return marks;
 }
 
-function wrapTextRange(range, commentId) {
+function wrapTextRange(range, commentId, isPrivate) {
   // Check if we're inside an SVG <text> element
   let node = range.commonAncestorContainer;
   while (node && node.nodeType !== Node.ELEMENT_NODE) {
@@ -91,7 +92,7 @@ function wrapTextRange(range, commentId) {
 
   // Regular HTML highlighting for HTML content
   const mark = document.createElement("mark");
-  mark.className = HIGHLIGHT_CLASS;
+  mark.className = HIGHLIGHT_CLASS + (isPrivate ? ` ${PRIVATE_CLASS}` : "");
   mark.dataset.commentId = commentId;
   mark.style.backgroundColor = "rgba(255, 212, 0, 0.35)";
   mark.style.cursor = "pointer";

--- a/feedback-layer/src/index.js
+++ b/feedback-layer/src/index.js
@@ -135,7 +135,8 @@ function init() {
 
 async function loadComments() {
   try {
-    _comments = await fetchComments(_docUri, _docId);
+    const viewer = getCommenter() || undefined;
+    _comments = await fetchComments(_docUri, _docId, { viewer });
     const anchored = await anchorAll(_comments);
     _anchoredIds = anchored;
     renderComments(_comments, _anchoredIds, _commentRanges);
@@ -163,7 +164,7 @@ async function anchorAll(comments) {
       );
 
       if (range && ann.status !== 'closed') {
-        highlightRange(range, ann.id);
+        highlightRange(range, ann.id, { isPrivate: ann.visibility === 'private' });
         anchored.add(ann.id);
         _commentRanges.set(ann.id, range);
       } else if (range && ann.status === 'closed') {
@@ -249,7 +250,7 @@ function removeTooltip() {
   }
 }
 
-async function handleCommentSubmit({ comment, commenter }) {
+async function handleCommentSubmit({ comment, commenter, visibility }) {
   if (!_pendingSelector) return;
 
   try {
@@ -261,6 +262,7 @@ async function handleCommentSubmit({ comment, commenter }) {
       suffix: _pendingSelector.suffix,
       body: comment,
       author: commenter,
+      visibility,
     });
 
     _comments.push(ann);
@@ -271,7 +273,7 @@ async function handleCommentSubmit({ comment, commenter }) {
       _root
     );
     if (range) {
-      highlightRange(range, ann.id);
+      highlightRange(range, ann.id, { isPrivate: ann.visibility === 'private' });
       _anchoredIds.add(ann.id);
     }
 
@@ -304,7 +306,7 @@ async function handleResolve(commentId, resolved) {
         _root
       );
       if (range) {
-        highlightRange(range, ann.id);
+        highlightRange(range, ann.id, { isPrivate: ann.visibility === 'private' });
         _anchoredIds.add(ann.id);
       } else {
         // Text no longer exists, remove from anchored set


### PR DESCRIPTION
Re-implements private/public annotation visibility. Closes #60.

## What changed
- **Server**: Added `visibility` column (`public`/`private`, default `public`) to comments table. `GET /comments` filters by viewer param — without it, only public comments are returned. `GET /comments/:id` returns 404 for private comments unless the viewer matches the author. `POST` and `PATCH` validate and persist visibility.
- **Client**: Added visibility toggle (lock icon) on the comment form. Private comments display with a dashed border highlight and a 🔒 badge in the sidebar. The viewer's identity (from the commenter name) is sent with all fetch requests so their own private comments are included.
- **Tests**: 9 new integration tests covering visibility on POST, GET (filtering), and PATCH.

## How to verify
1. Run `DATABASE_URL="postgresql://remarq:remarq@localhost:5433/remarq" npm run test:server` — all 71 tests pass.
2. Create a comment with the lock icon toggled to private → it should only be visible to the author.
3. Other viewers should not see private comments in the sidebar or as highlights.