### PR TITLE
Add build step requirement to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,16 @@ If the review agent requests changes, fix them on the same branch, push, and re-
 gh pr merge --squash --delete-branch
 ```
 
+## Build Step (Required)
+
+Whenever you modify any JS files in `feedback-layer/src/`, you **must** rebuild the served bundle:
+
+```bash
+cd feedback-layer && npm run build
+```
+
+This updates `serve/feedback-layer.js` which is what the server actually serves. If you skip this step, your changes will exist in source but won't be visible to users. Always commit the rebuilt `serve/feedback-layer.js` alongside your source changes.
+
 ## Documentation
 
 All functional changes (new features, changed behavior, new keyboard shortcuts, configuration options) must be documented in README.md before the PR is opened.


### PR DESCRIPTION
Adds a mandatory build step section to CLAUDE.md: whenever JS files in feedback-layer/src/ are modified, agents must run `cd feedback-layer && npm run build` and commit the rebuilt serve/feedback-layer.js alongside source changes. Prevents the stale bundle issue we hit on PR #153.