### PR TITLE
feat: add Open Graph and Twitter Card meta tags to marketing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Remarq — Google Docs is where feedback goes to die</title>
   <meta name="description" content="Drop-in document annotations for the agent era. One script tag on any HTML page. Your AI agent polls the API, revises the document, and resolves comments automatically. Self-hosted. No accounts needed.">
+  <meta property="og:title" content="Remarq — Google Docs is where feedback goes to die" />
+  <meta property="og:description" content="Drop-in document annotations for the agent era. One script tag on any HTML page. Your AI agent polls the API, revises the document, and resolves comments automatically. Self-hosted. No accounts needed." />
+  <meta property="og:image" content="https://cass-clearly.github.io/remarq/assets/remarq-social-preview.png" />
+  <meta property="og:url" content="https://cass-clearly.github.io/remarq/" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Remarq — Google Docs is where feedback goes to die" />
+  <meta name="twitter:description" content="Drop-in document annotations for the agent era. One script tag on any HTML page. Your AI agent polls the API, revises the document, and resolves comments automatically. Self-hosted. No accounts needed." />
+  <meta name="twitter:image" content="https://cass-clearly.github.io/remarq/assets/remarq-social-preview.png" />
   <link rel="icon" href="assets/favicon.ico" sizes="any">
   <link rel="icon" href="assets/favicon-192.png" type="image/png" sizes="192x192">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">


### PR DESCRIPTION
Adds Open Graph and Twitter Card meta tags to the marketing page `docs/index.html` so that sharing the page on social media shows:

- A compelling preview image (using the existing `remarq-social-preview.png`)
- The page title and description

The social preview image was already in the repo at `docs/assets/remarq-social-preview.png`.

Closes #112