### PR TITLE
Add Open Graph and Twitter Card meta tags to docs page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Remarq — Google Docs is where feedback goes to die</title>
   <meta name="description" content="Drop-in document annotations for the agent era. One script tag on any HTML page. Your AI agent polls the API, revises the document, and resolves comments automatically. Self-hosted. No accounts needed.">
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Remarq — Drop-in annotations that close the feedback loop">
+  <meta property="og:description" content="One script tag turns any HTML page into a reviewable document. Your AI agent reads the comments, revises the draft, and resolves feedback automatically. Self-hosted. No accounts needed.">
+  <meta property="og:url" content="https://cass-clearly.github.io/remarq/">
+  <meta property="og:image" content="https://cass-clearly.github.io/remarq/assets/remarq-social-preview.png">
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Remarq — Drop-in annotations that close the feedback loop">
+  <meta name="twitter:description" content="One script tag turns any HTML page into a reviewable document. Your AI agent reads the comments, revises the draft, and resolves feedback automatically. Self-hosted. No accounts needed.">
+  <meta name="twitter:image" content="https://cass-clearly.github.io/remarq/assets/remarq-social-preview.png">
   <link rel="icon" href="assets/favicon.ico" sizes="any">
   <link rel="icon" href="assets/favicon-192.png" type="image/png" sizes="192x192">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">


### PR DESCRIPTION
## What changed

Added Open Graph and Twitter Card meta tags to `docs/index.html` for rich link previews when the docs page is shared on social platforms (Slack, Twitter/X, Discord, LinkedIn, etc.).

Tags added:
- `og:type`, `og:title`, `og:description`, `og:url`, `og:image`
- `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`

Uses the existing `docs/assets/remarq-social-preview.png` image.

## Why

Closes #112 — Links to the docs page currently show a bare URL with no preview. Adding OG/Twitter meta tags gives shared links a compelling title, description, and image.

## How to verify

1. Open `docs/index.html` and confirm the meta tags are present in `<head>`
2. Validate with https://www.opengraph.xyz/ or the Twitter Card Validator
3. Share the deployed URL in Slack/Discord to confirm the preview renders

## Manual testing checklist

- [x] No console errors in browser DevTools
- [x] Existing tests pass (`npm test`) — no test changes needed (static HTML only)