### PR TITLE
fix: add shared/ directory to Dockerfile for v2.0.0

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY server/package*.json server/
 RUN cd server && npm ci --omit=dev
 COPY server/*.js server/
+COPY shared/ shared/
 COPY serve/ serve/
 EXPOSE 3333
 CMD ["node", "server/index.js"]


### PR DESCRIPTION
The v2.0.0 release added `shared/color-constants.js` which is required by `server/validate-color.js`, but the Dockerfile wasn't updated to COPY the `shared/` directory. This causes a MODULE_NOT_FOUND crash on startup.