### PR TITLE
feat: add security headers with helmet.js

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const express = require("express");
 const cors = require("cors");
+const helmet = require("helmet");
 const { Pool } = require("pg");
 const { insertWithId } = require("./generate-id.js");
 const { normalizeUri } = require("./normalize-uri.js");
@@ -11,6 +12,11 @@ const path = require("path");
 
 const app = express();
 app.use(cors());
+app.use(helmet({
+  contentSecurityPolicy: false,
+  crossOriginEmbedderPolicy: false,
+  crossOriginResourcePolicy: false,
+}));
 app.use(express.json());
 
 const DATABASE_URL = process.env.DATABASE_URL || "postgresql://postgres@localhost/postgres";

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.0",
+        "helmet": "^8.1.0",
         "pg": "^8.13.0"
       },
       "bin": {
@@ -415,6 +416,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.21.0",
+    "helmet": "^8.1.0",
     "pg": "^8.13.0"
   }
 }

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -172,6 +172,30 @@ describe("API", async () => {
     });
   });
 
+  // ── Security headers ─────────────────────────────────────────
+
+  describe("security headers", () => {
+    it("sets X-Content-Type-Options", async () => {
+      const res = await fetch(`${BASE}/health`);
+      assert.equal(res.headers.get("x-content-type-options"), "nosniff");
+    });
+
+    it("sets Strict-Transport-Security", async () => {
+      const res = await fetch(`${BASE}/health`);
+      assert.ok(res.headers.get("strict-transport-security"));
+    });
+
+    it("sets X-Frame-Options", async () => {
+      const res = await fetch(`${BASE}/health`);
+      assert.equal(res.headers.get("x-frame-options"), "SAMEORIGIN");
+    });
+
+    it("does not set Content-Security-Policy (disabled for embeds)", async () => {
+      const res = await fetch(`${BASE}/health`);
+      assert.equal(res.headers.get("content-security-policy"), null);
+    });
+  });
+
   // ── Documents ─────────────────────────────────────────────────
 
   describe("GET /documents", () => {


### PR DESCRIPTION
## What changed

Added [helmet.js](https://helmetjs.github.io/) middleware to the Express server to set standard security headers on all responses. Helmet is configured with CSP and cross-origin embedder/resource policies disabled, since the feedback layer is designed to be embedded in third-party pages.

Headers now set by helmet:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN`
- `Strict-Transport-Security` (HSTS)
- `X-DNS-Prefetch-Control`
- `X-Download-Options`
- `X-Permitted-Cross-Domain-Policies`

## Why

Closes #185 — Adding security headers hardens the server against common web vulnerabilities (MIME-type sniffing, clickjacking, etc.) with minimal effort.

## How to verify

1. Run the new tests:
   ```
   DATABASE_URL="postgresql://remarq:remarq@localhost:5433/remarq" npm run test:server
   ```
2. Verify headers with curl:
   ```
   curl -I http://localhost:3333/health
   ```
   You should see `x-content-type-options: nosniff`, `x-frame-options: SAMEORIGIN`, and `strict-transport-security` in the response headers.

## Manual testing checklist

- [x] Server starts without errors (`npm run start`)
- [x] Existing tests pass (`npm test`) — 1 pre-existing failure in emoji test unrelated to this PR
- [ ] Tested in browser (annotations, sidebar, highlights work)
- [x] Tested API changes with curl (include example commands above)
- [ ] No console errors in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)