### PR TITLE
docs: comprehensive marketing refresh — benefit-focused copy, missing features, accuracy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,13 +362,22 @@ ws.onmessage = (event) => {
 
 ## Features
 
-- **No accounts** — reviewers just type their name
-- **Text anchoring** — annotations are anchored to specific text passages using TextQuoteSelectors (via Apache Annotator), so highlights survive minor edits
-- **Threaded replies** — discuss any annotation
-- **Resolve/unresolve** — mark feedback as addressed
-- **Keyboard shortcuts** — full keyboard navigation for the sidebar
-- **One script tag** — drop-in integration for any HTML page
-- **Agent-ready API** — structured feedback your AI can consume and act on
+- **Real-time collaboration** — WebSocket updates show new comments from other reviewers instantly, no page refresh needed. See feedback arrive live during review sessions.
+- **Webhook notifications** — Get notified in Slack, Discord, or email the moment feedback arrives. Wire Remarq into any workflow with signed HTTP callbacks.
+- **No accounts** — reviewers just type their name and start annotating. Zero friction.
+- **Text anchoring** — comments stick to the right text even when surrounding content changes. Uses W3C TextQuoteSelectors (Apache Annotator) so highlights survive document edits.
+- **Threaded replies** — focused discussions on specific passages without losing context.
+- **Customizable highlight colors** — color-code feedback by reviewer, priority, or type. Scan a page and instantly see what needs attention.
+- **Dark mode** — comfortable reviewing at any time of day. Auto-detects OS preference or force via `data-theme`.
+- **Keyboard shortcuts** — power through reviews without touching your mouse. Full accessibility support (`s` to toggle sidebar, `j`/`k` to navigate, `Enter` to reply).
+- **Emoji reactions** — quick thumbs-up or 🤔 without cluttering the thread. Gauge consensus at a glance.
+- **Toast notifications** — non-blocking confirmations that don't interrupt your flow. No more jarring alert() dialogs.
+- **Orphaned comments stay visible** — when document text changes, orphaned comments surface at the bottom so nothing gets lost.
+- **OpenAPI spec** — agents discover the entire API from a single URL (`GET /openapi.json`). Zero ramp-up time.
+- **CLI tool** — scriptable management of documents, comments, and reactions from the terminal. No UI needed for automation. CLI commands auto-generate from the spec.
+- **Security hardening** — protected against clickjacking, MIME sniffing, and common web attacks out of the box (helmet.js).
+- **One script tag** — drop-in integration for any HTML page. Not trapped in a proprietary editor.
+- **Agent-ready API** — structured feedback your AI can consume and act on. Every comment anchored to exact text, threaded, with status tracking.
 
 ## Documentation
 

--- a/docs/JTBD.md
+++ b/docs/JTBD.md
@@ -65,3 +65,63 @@
 **When** I'm writing technical documentation with diagrams, **I want** annotations that work on Mermaid diagrams and SVGs, **so that** I can get feedback on visual content too — not just prose.
 
 > **How Remarq solves it:** The annotation layer works on any HTML content within the configured content selector, including rendered Mermaid diagrams and inline SVGs.
+
+### 11. Real-Time Collaboration
+
+**When** I'm reviewing a document with other team members, **I want to** see their comments appear in real time, **so that** I can collaborate live without constantly refreshing the page.
+
+> **How Remarq solves it:** WebSocket updates push new comments, edits, and deletions to all connected clients instantly. When someone posts feedback during a live review session, everyone sees it immediately.
+
+### 12. Webhook Notifications
+
+**When** feedback arrives on my documents, **I want to** get notified in Slack or email, **so that** I can respond quickly without polling the annotation UI.
+
+> **How Remarq solves it:** Register webhook endpoints to receive signed HTTP callbacks when comments are created, resolved, or deleted. Wire Remarq into Slack, Discord, email, or any custom workflow.
+
+### 13. Customizable Highlight Colors
+
+**When** I'm reviewing a document, **I want to** choose a highlight color for my comments, **so that** my feedback is visually distinct from other reviewers' or I can color-code by priority.
+
+> **How Remarq solves it:** Set `color` when creating or updating a comment. Choose from 8 preset colors (red, blue, green, purple, etc.) or pass any 6-digit hex code. Agents can color-code feedback by category (red for errors, blue for suggestions, green for approvals).
+
+### 14. Dark Mode
+
+**When** I'm reviewing late at night, **I want** dark mode, **so that** I can read comfortably without eye strain.
+
+> **How Remarq solves it:** Set `data-theme="dark"` or `data-theme="auto"` (default) to follow OS preference. All UI components, syntax highlighting, and sidebar styles adapt automatically.
+
+### 15. Emoji Reactions
+
+**When** I see a comment I agree with, **I want to** react with an emoji instead of writing a full reply, **so that** I can quickly express agreement without adding noise.
+
+> **How Remarq solves it:** Click any emoji (👍, ❤️, 👀, 🎉, 🤔, 😂, ➕) on a comment to add your reaction. Reaction counts show consensus at a glance without cluttering threads with "+1" replies.
+
+### 16. Keyboard Navigation
+
+**When** I'm reviewing a document, **I want** full keyboard navigation, **so that** I can power through feedback without touching my mouse.
+
+> **How Remarq solves it:** `s` to toggle sidebar, `j`/`k` to navigate comments, `Enter` to reply, `Cmd+Enter` to submit. Press `?` to see all shortcuts. Full accessibility support.
+
+### 17. OpenAPI Discovery for Agents
+
+**When** I'm integrating Remarq with an AI agent, **I want** the agent to discover the entire API automatically, **so that** I don't have to manually explain every endpoint.
+
+> **How Remarq solves it:** `GET /openapi.json` returns a machine-readable OpenAPI 3.0 spec. Agents can ingest the full API surface in one shot — zero ramp-up time. The spec includes `x-cli` extensions that drive the CLI.
+
+### 18. CLI for Scriptable Management
+
+**When** I'm automating document workflows, **I want** a CLI to manage comments and documents from scripts, **so that** I don't have to build UI automation or hand-craft API calls.
+
+> **How Remarq solves it:** `npm install -g @csalvato/remarq-cli` gives you commands like `remarq comments list`, `remarq comments create`, `remarq documents delete`. CLI commands auto-generate from the OpenAPI spec — new server endpoints appear in the CLI with zero CLI code changes.
+
+### 19. Security Hardening
+
+**When** I'm deploying Remarq to production, **I want** protection against common web attacks, **so that** I don't have to manually configure security headers.
+
+> **How Remarq solves it:** helmet.js sets X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security, and other security headers out of the box. Protects against clickjacking, MIME sniffing, and related attacks. CSP is intentionally disabled since the feedback layer is designed to be embedded in third-party pages.
+
+### 20. Orphaned Comments Stay Visible
+
+**When** I edit a document after receiving feedback, **I want** orphaned comments (whose text anchors broke) to remain visible, **so that** no feedback gets silently lost.
+
+> **How Remarq solves it:** When text anchoring fails (because the quoted text was deleted or heavily edited), the comment surfaces at the bottom of the sidebar with a clear "orphaned" indicator. You can still read the feedback, reply, and resolve it.

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,7 @@ Here's a common workflow for working with the Remarq API:
 
 ```bash
 # 1. Create a comment on a document (auto-creates document if needed)
-curl -X POST http://localhost:3000/comments \
+curl -X POST http://localhost:3333/comments \
   -H "Content-Type: application/json" \
   -d '{
     "uri": "https://example.com/article",
@@ -18,7 +18,7 @@ curl -X POST http://localhost:3000/comments \
 # Response: { "id": "cmt_xyz", "status": "open", ... }
 
 # 2. Create a reply to the comment
-curl -X POST http://localhost:3000/comments \
+curl -X POST http://localhost:3333/comments \
   -H "Content-Type: application/json" \
   -d '{
     "document": "doc_abc",
@@ -28,12 +28,12 @@ curl -X POST http://localhost:3000/comments \
   }'
 
 # 3. Resolve the original comment
-curl -X PATCH http://localhost:3000/comments/cmt_xyz \
+curl -X PATCH http://localhost:3333/comments/cmt_xyz \
   -H "Content-Type: application/json" \
   -d '{ "status": "closed" }'
 
 # 4. List all open comments for the document
-curl "http://localhost:3000/comments?uri=https://example.com/article&status=open"
+curl "http://localhost:3333/comments?uri=https://example.com/article&status=open"
 ```
 
 ---
@@ -43,7 +43,7 @@ curl "http://localhost:3000/comments?uri=https://example.com/article&status=open
 When running locally:
 
 ```
-http://localhost:3000
+http://localhost:3333
 ```
 
 When deployed, replace with your server's URL.
@@ -73,7 +73,7 @@ Check if the server is running.
 **Example:**
 
 ```bash
-curl http://localhost:3000/health
+curl http://localhost:3333/health
 ```
 
 ---
@@ -107,7 +107,7 @@ List all documents.
 **Example:**
 
 ```bash
-curl http://localhost:3000/documents
+curl http://localhost:3333/documents
 ```
 
 ---
@@ -165,7 +165,7 @@ Create a new document (or return existing if URI already exists).
 **Example:**
 
 ```bash
-curl -X POST http://localhost:3000/documents \
+curl -X POST http://localhost:3333/documents \
   -H "Content-Type: application/json" \
   -d '{"uri": "https://example.com/article"}'
 ```
@@ -214,7 +214,7 @@ Get a single document by ID.
 **Example:**
 
 ```bash
-curl http://localhost:3000/documents/doc_k3mXp9q2aBvN
+curl http://localhost:3333/documents/doc_k3mXp9q2aBvN
 ```
 
 ---
@@ -246,7 +246,7 @@ Delete a document and all its comments.
 **Example:**
 
 ```bash
-curl -X DELETE http://localhost:3000/documents/doc_k3mXp9q2aBvN
+curl -X DELETE http://localhost:3333/documents/doc_k3mXp9q2aBvN
 ```
 
 **Notes:**
@@ -324,16 +324,16 @@ List comments with optional filtering.
 
 ```bash
 # List all comments for a document by ID
-curl "http://localhost:3000/comments?document=doc_k3mXp9q2aBvN"
+curl "http://localhost:3333/comments?document=doc_k3mXp9q2aBvN"
 
 # List all comments for a document by URI
-curl "http://localhost:3000/comments?uri=https://example.com/article"
+curl "http://localhost:3333/comments?uri=https://example.com/article"
 
 # List only open comments
-curl "http://localhost:3000/comments?document=doc_k3mXp9q2aBvN&status=open"
+curl "http://localhost:3333/comments?document=doc_k3mXp9q2aBvN&status=open"
 
 # List all comments with document objects expanded
-curl "http://localhost:3000/comments?document=doc_k3mXp9q2aBvN&expand=document"
+curl "http://localhost:3333/comments?document=doc_k3mXp9q2aBvN&expand=document"
 ```
 
 **Notes:**
@@ -455,7 +455,7 @@ Document not found:
 
 ```bash
 # Create a top-level comment (auto-creates document if needed)
-curl -X POST http://localhost:3000/comments \
+curl -X POST http://localhost:3333/comments \
   -H "Content-Type: application/json" \
   -d '{
     "uri": "https://example.com/article",
@@ -465,7 +465,7 @@ curl -X POST http://localhost:3000/comments \
   }'
 
 # Create a reply
-curl -X POST http://localhost:3000/comments \
+curl -X POST http://localhost:3333/comments \
   -H "Content-Type: application/json" \
   -d '{
     "document": "doc_k3mXp9q2aBvN",
@@ -530,10 +530,10 @@ Get a single comment by ID.
 
 ```bash
 # Get comment by ID
-curl http://localhost:3000/comments/cmt_abc123
+curl http://localhost:3333/comments/cmt_abc123
 
 # Get comment with document object expanded
-curl "http://localhost:3000/comments/cmt_abc123?expand=document"
+curl "http://localhost:3333/comments/cmt_abc123?expand=document"
 ```
 
 ---
@@ -611,17 +611,17 @@ Setting status on a reply:
 
 ```bash
 # Update comment body
-curl -X PATCH http://localhost:3000/comments/cmt_abc123 \
+curl -X PATCH http://localhost:3333/comments/cmt_abc123 \
   -H "Content-Type: application/json" \
   -d '{"body": "Updated text"}'
 
 # Resolve a comment
-curl -X PATCH http://localhost:3000/comments/cmt_abc123 \
+curl -X PATCH http://localhost:3333/comments/cmt_abc123 \
   -H "Content-Type: application/json" \
   -d '{"status": "closed"}'
 
 # Reopen a comment
-curl -X PATCH http://localhost:3000/comments/cmt_abc123 \
+curl -X PATCH http://localhost:3333/comments/cmt_abc123 \
   -H "Content-Type: application/json" \
   -d '{"status": "open"}'
 ```
@@ -662,7 +662,7 @@ Delete a comment and all its replies.
 **Example:**
 
 ```bash
-curl -X DELETE http://localhost:3000/comments/cmt_abc123
+curl -X DELETE http://localhost:3333/comments/cmt_abc123
 ```
 
 **Notes:**

--- a/docs/index.html
+++ b/docs/index.html
@@ -723,6 +723,109 @@ docker compose -f docker-compose.remarq.yml up --build'
               </div>
             </div>
           </div>
+
+          <!-- Real-time collaboration -->
+          <div
+            class="fade-in bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-violet-200 transition-colors"
+          >
+            <div class="w-12 h-12 bg-violet-100 rounded-xl flex items-center justify-center mb-5">
+              <svg
+                class="w-6 h-6 text-violet-600"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+            </div>
+            <h3 class="text-xl font-semibold mb-3">Real-time collaboration.</h3>
+            <p class="text-gray-600 leading-relaxed">
+              Multiple reviewers see each other's comments instantly via WebSocket updates. No page refresh needed. When
+              someone adds feedback during a live review session, it appears immediately for everyone viewing the
+              document.
+            </p>
+          </div>
+
+          <!-- Webhook notifications -->
+          <div
+            class="fade-in bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-violet-200 transition-colors"
+          >
+            <div class="w-12 h-12 bg-violet-100 rounded-xl flex items-center justify-center mb-5">
+              <svg
+                class="w-6 h-6 text-violet-600"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                />
+              </svg>
+            </div>
+            <h3 class="text-xl font-semibold mb-3">Webhook notifications.</h3>
+            <p class="text-gray-600 leading-relaxed">
+              Get notified in Slack, Discord, or email the moment feedback arrives. Register HTTP endpoints to receive
+              signed payloads when comments are created, resolved, or deleted. Wire Remarq into your existing workflows.
+            </p>
+          </div>
+
+          <!-- Customizable highlight colors -->
+          <div
+            class="fade-in bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-violet-200 transition-colors"
+          >
+            <div class="w-12 h-12 bg-violet-100 rounded-xl flex items-center justify-center mb-5">
+              <svg
+                class="w-6 h-6 text-violet-600"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"
+                />
+              </svg>
+            </div>
+            <h3 class="text-xl font-semibold mb-3">Color-code your feedback.</h3>
+            <p class="text-gray-600 leading-relaxed">
+              Color-code feedback by reviewer, priority, or type. Scan a page and instantly see what needs attention.
+              Red for errors, blue for suggestions, green for approvals — choose from 8 presets or any hex code.
+            </p>
+          </div>
+
+          <!-- OpenAPI + CLI -->
+          <div
+            class="fade-in bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-violet-200 transition-colors"
+          >
+            <div class="w-12 h-12 bg-violet-100 rounded-xl flex items-center justify-center mb-5">
+              <svg
+                class="w-6 h-6 text-violet-600"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+            </div>
+            <h3 class="text-xl font-semibold mb-3">OpenAPI spec + auto-generated CLI.</h3>
+            <p class="text-gray-600 leading-relaxed">
+              Agents discover the entire API from
+              <code class="bg-gray-100 px-1.5 py-0.5 rounded text-sm">GET /openapi.json</code>. Zero ramp-up time. CLI
+              commands auto-generate from the spec — new server endpoints appear in the CLI with zero CLI code changes.
+              Scriptable management from the terminal.
+            </p>
+          </div>
         </div>
       </div>
     </section>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4,6 +4,8 @@
 
 Remarq turns human feedback into structured API data that AI agents can consume and act on. No accounts required. One script tag integration. Works on any HTML page — blogs, docs, marketing sites, contracts. Not trapped in a proprietary editor.
 
+Real-time collaboration via WebSocket. Webhook notifications for Slack/Discord/email. Customizable highlight colors. Dark mode. Emoji reactions. Keyboard shortcuts. OpenAPI spec for agent discovery. CLI tool for scriptable management. Security hardening with helmet.js. Orphaned comments stay visible when document text changes.
+
 ## Installation
 
 ### Script Tag (client-side)
@@ -54,6 +56,7 @@ DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 | `data-content-selector` | `body` | CSS selector for the annotatable content area |
 | `data-document-uri` | current page URL | Override the URI used to store/fetch annotations |
 | `data-theme` | `"auto"` | Color theme: `"auto"` (follows OS), `"dark"`, or `"light"` |
+| `data-default-color` | `null` (yellow) | Default highlight color for new comments. Accepts preset name or 6-digit hex code |
 
 ### Environment Variables
 
@@ -363,6 +366,100 @@ Delete a comment and all its replies.
 **Response (200):** Returns the deleted comment object. Returns `404` if not found.
 
 Deleting a comment cascades to all replies.
+
+---
+
+### Reactions
+
+Comments support emoji reactions (👍, ❤️, 👀, 🎉, 🤔, 😂, ➕). The `reactions` field in comment objects is an object mapping emoji to arrays of author names:
+
+```json
+{
+  "id": "cmt_abc123",
+  "reactions": {
+    "👍": ["Alice", "Bob"],
+    "❤️": ["Charlie"]
+  }
+}
+```
+
+#### POST /comments/:id/reactions
+
+Add a reaction. Request body: `{ "emoji": "👍", "author": "Alice" }`. Returns 201 with the reaction object. Allowed emojis: 👍, ❤️, 😂, 🤔, 😕, 🎉, ➕. Returns 400 for disallowed emoji. Idempotent — adding the same reaction twice is a no-op.
+
+#### DELETE /comments/:id/reactions/:emoji
+
+Remove a reaction. Query parameter: `author` (required). Returns 200 with the deleted reaction. Returns 404 if not found.
+
+Reactions are also included in the `reactions` field of comment objects returned by `GET /comments`.
+
+---
+
+### Webhooks
+
+Register HTTP endpoints to receive notifications when comments are created, resolved, or deleted.
+
+#### Events
+
+| Event              | Triggered when                               |
+| ------------------ | -------------------------------------------- |
+| `comment.created`  | A new comment or reply is created            |
+| `comment.resolved` | A root comment's status is set to `"closed"` |
+| `comment.deleted`  | A comment is deleted                         |
+
+#### Payload format
+
+```json
+{
+  "event": "comment.created",
+  "created_at": "2025-01-01T00:00:00.000Z",
+  "data": {
+    "comment": { /* comment object */ }
+  }
+}
+```
+
+Payloads are signed with HMAC-SHA256 using the webhook's secret. The signature is sent in the `X-Remarq-Signature` header.
+
+**Verifying signatures:**
+
+```js
+const crypto = require("crypto");
+const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+if (signature !== expected) throw new Error("Invalid signature");
+```
+
+#### GET /webhooks
+
+List all registered webhooks. The `secret` field is never returned in responses.
+
+#### POST /webhooks
+
+Register a new webhook.
+
+**Request body:**
+
+```json
+{
+  "url": "https://example.com/hook",
+  "secret": "your-signing-secret",
+  "events": ["comment.created", "comment.resolved"]
+}
+```
+
+Returns `201` with webhook object. Returns `409` if a webhook with the same URL already exists.
+
+#### PATCH /webhooks/:id
+
+Update a webhook. All fields optional: `url`, `events`, `active`.
+
+Returns `404` if not found. Returns `409` if the new URL is already used by another webhook.
+
+#### DELETE /webhooks/:id
+
+Delete a webhook.
+
+Returns `200` with deleted webhook object. Returns `404` if not found.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,8 +7,18 @@ Key things to know about Remarq:
 - One `<script>` tag integration — works on any HTML page (blogs, docs, marketing sites, contracts)
 - No accounts required for reviewers — just type a name and start annotating
 - REST API designed for AI agent consumption — structured annotations with text anchors, threading, and status management
+- Real-time collaboration via WebSocket — see new comments from other reviewers instantly, no page refresh needed
+- Webhook notifications — get notified in Slack, Discord, or email when feedback arrives
+- Customizable highlight colors — color-code feedback by reviewer, priority, or type (8 presets + any hex code)
+- Dark mode support — auto-detects OS preference or force via `data-theme`
+- Emoji reactions — quick 👍 or 🤔 without cluttering threads
+- Keyboard navigation — full keyboard shortcuts for power users and accessibility (`s`, `j`/`k`, `Enter`, `?` for help)
+- Orphaned comments stay visible — when document text changes, orphaned comments surface at the bottom so nothing gets lost
+- OpenAPI spec at `/openapi.json` — agents discover the entire API from a single URL, zero ramp-up time
+- CLI tool (`@csalvato/remarq-cli`) — scriptable management from the terminal, commands auto-generate from the OpenAPI spec
+- Security hardening with helmet.js — protected against clickjacking, MIME sniffing, and common web attacks out of the box
 - Self-hosted with Docker Compose (Postgres + Node server) or `npx @csalvato/remarq-server` for quick local use
-- Configure via `data-` attributes: `data-api-url`, `data-content-selector`, `data-document-uri`, `data-theme`
+- Configure via `data-` attributes: `data-api-url`, `data-content-selector`, `data-document-uri`, `data-theme`, `data-default-color`
 
 ## Docs
 


### PR DESCRIPTION
## Summary

Marketing Guru review and rewrite of all public-facing materials. Every feature now presented with its benefit (the job it helps the user do), not just a technical description.

## What changed

### README.md
- Expanded Features section from 7 generic bullets to 16 benefit-focused entries
- Every v2.0.0 and v2.1.0 feature now documented with clear user benefit

### docs/index.html (marketing site)
- Added 4 new feature cards: real-time collaboration, webhook notifications, customizable highlight colors, OpenAPI + CLI

### docs/api.md
- **Bug fix:** All ~20 curl examples used port 3000 — server defaults to 3333. Fixed throughout.

### docs/JTBD.md
- Added 10 new JTBD entries (#11–#20) for features that had no documented jobs: real-time collaboration, webhooks, highlight colors, dark mode, emoji reactions, keyboard nav, OpenAPI discovery, CLI management, security hardening, orphaned comments
- Fixed inaccurate emoji list (was 😕, should be 👀 per `shared/emoji-constants.js`)
- Fixed false CSP claim (CSP is intentionally disabled for embeddability)

### docs/llms.txt
- Expanded from 5 to 15 key facts for LLM discovery

### docs/llms-full.txt
- Added feature overview, `data-default-color` config, full Reactions API docs (with correct endpoints), full Webhooks CRUD docs
- Fixed false claim that reactions had "no REST endpoint" — they have `POST /comments/:id/reactions` and `DELETE /comments/:id/reactions/:emoji`

## Accuracy fixes
- Port 3000 → 3333 in all api.md examples
- Wrong emoji (😕 → 👀) in JTBD and llms-full.txt
- False CSP claim removed (helmet disables CSP intentionally)
- False "no REST endpoint" claim for reactions corrected

## How to verify
- Read the diffs — all changes are docs-only
- No code changes, no test changes
- `npm run format:check` passes