### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## v2.3.0 (2026-03-01)
+
 ### Added
 
 - Markdown formatting in comments: `**bold**`/`__bold__`, `*italic*`/`_italic_`, `` `code` ``, and `[links](url)` (#67)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remarq",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "private": true,
   "license": "AGPL-3.0",
   "description": "Drop-in annotation and comment layer for any HTML page.",


### PR DESCRIPTION
## What changed

Version bump to 2.3.0 and CHANGELOG update for release.

## Why

Release v2.3.0 with:
- **Added:** Markdown formatting in comments (#67), formatting hints, XSS protection
- **Fixed:** Duplicate sidebar comments from WebSocket echo (#132), scroll-to-top on comment box open (#194)

## How to verify

- `npm run check` passes
- CHANGELOG has correct date and version
- package.json version is 2.3.0