### PR TITLE
fix: restrict CORS to trusted origins via ALLOWED_ORIGINS (#184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
+### Environment Variables
+
+| Variable          | Default                                    | Description                                                                                          |
+| ----------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`    | `postgresql://postgres@localhost/postgres` | PostgreSQL connection string                                                                         |
+| `PORT`            | `3333`                                     | HTTP server listen port                                                                              |
+| `ALLOWED_ORIGINS` | `http://localhost:3333`                    | Comma-separated list of origins allowed by CORS (e.g. `https://example.com,https://app.example.com`) |
+
 ## OpenAPI Spec
 
 The server exposes a machine-readable OpenAPI 3.0 spec at:

--- a/docker-compose.remarq.yml
+++ b/docker-compose.remarq.yml
@@ -24,6 +24,7 @@ services:
     environment:
       DATABASE_URL: postgres://remarq:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres/remarq
       PORT: "3333"
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:3333}
     depends_on:
       postgres:
         condition: service_healthy

--- a/server/index.js
+++ b/server/index.js
@@ -17,7 +17,8 @@ const path = require("path");
 const openApiSpec = require("./openapi.js");
 
 const app = express();
-app.use(cors());
+const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : ["http://localhost:3333"];
+app.use(cors({ origin: allowedOrigins, credentials: true }));
 app.use(
   helmet({
     contentSecurityPolicy: false,


### PR DESCRIPTION
## What changed

- `server/index.js`: Replaced open `cors()` with origin-restricted config using `ALLOWED_ORIGINS` env var
- `docker-compose.remarq.yml`: Passes `ALLOWED_ORIGINS` to the server container (defaults to `http://localhost:3333`)
- `README.md`: Added Environment Variables table documenting `DATABASE_URL`, `PORT`, and `ALLOWED_ORIGINS`

## Why

Closes #184. The server used `app.use(cors())` with no configuration, allowing requests from any origin. This is a security risk in production — CORS should restrict allowed origins to trusted domains.

## How to verify

```bash
# Default (no env var) — only localhost:3333 allowed
node server/index.js

# Custom origins
ALLOWED_ORIGINS=https://example.com,https://app.example.com node server/index.js

# Verify CORS headers
curl -i -H "Origin: https://evil.com" http://localhost:3333/health
# → No Access-Control-Allow-Origin header

curl -i -H "Origin: http://localhost:3333" http://localhost:3333/health
# → Access-Control-Allow-Origin: http://localhost:3333
# → Access-Control-Allow-Credentials: true
```

## Manual testing checklist

- [x] Existing tests pass (`npm run test:server` — 135 pass, 98.63% coverage)
- [x] Lint passes (`npm run lint`)
- [x] Format passes (`npm run format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)