### PR TITLE
fix: consolidate stack and correct council persona paths

### DIFF
--- a/agents/implementor/AGENTS.md
+++ b/agents/implementor/AGENTS.md
@@ -18,8 +18,7 @@ Ship features that make Remarq the obvious replacement for Google Docs commentin
 - **Role:** Full-stack IC — plans, implements, ships
 - **Reports to:** CEO
 - **Reviewed by:** The Council (5 members, all reviewers, none write code)
-- **Open Source Stack:** Node.js, node:test, c8 coverage, ESLint, Prettier
-- **Closed Source Stack:** Ruby on Rails, rubocop, syntax-tree, simplecov, minitest
+- **Stack:** Node.js, node:test, c8 coverage, ESLint, Prettier
 - **Codebase:** Server, client library (feedback-layer), CLI
 
 ## Engineering Principles
@@ -140,13 +139,13 @@ Spawn all five Council members against the PR using the template in CLAUDE.md. E
 
 The Council members:
 
-| Role               | File                        | Focus                               |
-| ------------------ | --------------------------- | ----------------------------------- |
-| The Minimalist     | `council/minimalist.md`     | Scope, simplicity, delete-first     |
-| The Craftsperson   | `council/craftsperson.md`   | TDD, refactoring, code quality      |
-| The Steward        | `council/steward.md`        | API stability, production readiness |
-| The Architect      | `council/architect.md`      | Coherence, shipping, tiebreaker     |
-| The Marketing Guru | `council/marketing-guru.md` | Docs, changelog, brand consistency  |
+| Role               | File                               | Focus                               |
+| ------------------ | ---------------------------------- | ----------------------------------- |
+| The Minimalist     | `agents/council/minimalist.md`     | Scope, simplicity, delete-first     |
+| The Craftsperson   | `agents/council/craftsperson.md`   | TDD, refactoring, code quality      |
+| The Steward        | `agents/council/steward.md`        | API stability, production readiness |
+| The Architect      | `agents/council/architect.md`      | Coherence, shipping, tiebreaker     |
+| The Marketing Guru | `agents/council/marketing-guru.md` | Docs, changelog, brand consistency  |
 
 The Architect breaks ties. The Marketing Guru reviews every PR. No human review needed unless the Council explicitly flags it.
 
@@ -210,4 +209,4 @@ Pure functions live in `feedback-layer/src/utils/` as individual modules. Import
 
 Use the CLAUDE.md at the repo root as your primary reference. It contains the engineering principles, Council process, git workflow, testing conventions, and everything you need to ship.
 
-Read `council/*.md` before spawning any reviewer — each has a specific personality and set of principles they enforce.
+Read `agents/council/*.md` before spawning any reviewer — each has a specific personality and set of principles they enforce.

--- a/agents/implementor/TOOLS.md
+++ b/agents/implementor/TOOLS.md
@@ -40,5 +40,5 @@ gh pr merge --squash --delete-branch
 
 1. **Tests first.** Run the test suite before and after every change. If tests break, you broke them — fix them before anything else.
 2. **CI is the gatekeeper.** Don't request Council review until CI is green. Reviewing broken code wastes everyone's time.
-3. **Read the council personas.** Before spawning reviewers, read `council/*.md`. Each reviewer has specific principles they enforce. Know what they'll look for.
+3. **Read the council personas.** Before spawning reviewers, read `agents/council/*.md`. Each reviewer has specific principles they enforce. Know what they'll look for.
 4. **Small commits, clear messages.** Each commit should be independently understandable. Never force-push main.


### PR DESCRIPTION
## What changed

- Consolidated "Open Source Stack" and "Closed Source Stack" into a single "Stack" entry in `agents/implementor/AGENTS.md` (Rails is not in the Remarq codebase)
- Fixed 8 references from `council/*.md` to `agents/council/*.md` across `agents/implementor/AGENTS.md` and `agents/implementor/TOOLS.md`

## Why

PR #226 reorganized the directory structure (moving `council/` → `agents/council/`) but the implementor agent files still referenced the old paths. The dual-stack listing was also inaccurate — Remarq is Node.js only.

Supersedes PR #227 (closed — most content was already merged via #226, only these fixes remained).

## How to verify

- Verify `agents/council/*.md` files exist at the referenced paths
- `grep -r 'council/' agents/implementor/` should only show `agents/council/` prefixed paths

## Manual testing checklist

- [x] No code changes — documentation/config only
- [x] Verified `agents/council/*.md` files exist at the correct paths
- [x] No remaining references to `council/*.md` without the `agents/` prefix