### PR TITLE
Add coding standards and ADR reference to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ Each member has a detailed persona file in `agents/council/`. Read the full file
 
 > **📣 The Marketing Guru** reviews every PR. Every change is an opportunity to ensure documentation, changelogs, and public-facing materials reflect what's shipping. The Marketing Guru checks that new features are discoverable, the changelog is current, and the brand narrative stays consistent — Google Docs is the villain we're conquering.
 
+### Architecture Decision Records
+
+The Architect maintains ADRs in `decisions/`. When the council makes a significant architectural decision, the Architect creates an ADR in the same PR. See `decisions/README.md` for format and guidelines. Existing ADRs should be consulted before proposing changes that might contradict settled decisions.
+
 ### How to Spawn Council Members
 
 For each council member, spawn a fresh agent with this template:
@@ -181,6 +185,26 @@ The Council approves. Human review is not required unless the Council explicitly
 ```
 gh pr merge --squash --delete-branch
 ```
+
+---
+
+## Coding Standards
+
+These rules apply to all Claude Code and Pi sessions working on this codebase.
+
+**Run tests before committing.** No exceptions. `npm test` must pass before `git commit`. Don't commit broken code and "fix it in the next commit."
+
+**Check CI status before starting review.** Never review code on a red CI. Fix CI first, then review. Reviewing failing code wastes everyone's time.
+
+**Read files before editing.** Always read the full file (or relevant section) before making changes. Don't edit based on assumptions about file contents.
+
+**No excessive apologies.** When something breaks or a mistake is made, fix it. Don't waste tokens on apologies — spend them on solutions.
+
+**Max 3 retries.** If an approach fails 3 times, stop and reassess. Try a fundamentally different approach, or ask for help. Don't keep bashing the same wall.
+
+**Think before critical actions.** Before any destructive operation (deleting files, force-pushing, dropping tables, resetting state), pause and verify: is this the right target? Is there a backup? Can this be undone?
+
+**Batch independent tool calls.** When multiple tool calls have no dependencies between them, make them all in the same batch. Don't serialize independent work.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds behavioral rules to CLAUDE.md derived from analyzing 964 Claude Code sessions and 37 Pi sessions. Also adds a reference to the ADR system in the Council section.

## Coding Standards Added

Rules based on patterns observed across all sessions:

- **Run tests before committing** — most common source of CI failures
- **Check CI before review** — ~10+ sessions wasted reviewing red CI
- **Read files before editing** — prevents edits based on wrong assumptions
- **No excessive apologies** — spend tokens on solutions, not sorry
- **Max 3 retries** — stop bashing the wall, try a different approach
- **Think before critical actions** — destructive ops need a pause
- **Batch independent tool calls** — don't serialize parallel work

## ADR Reference

Added pointer to `decisions/` directory in the Council section so reviewers consult existing ADRs before proposing contradictory changes.

## Context

Analysis of session data showed these are the most impactful behavioral improvements based on actual usage patterns.