### PR TITLE
fix: landing page accessibility and UX improvements

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -412,6 +412,15 @@
         color: var(--color-hero-text);
       }
 
+      /* -- Reduced motion -- */
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          transition-duration: 0.01ms !important;
+        }
+      }
+
       /* -- Responsive -- */
       @media (min-width: 768px) {
         .hero {
@@ -433,11 +442,11 @@
     <!-- Nav -->
     <nav class="nav" id="navbar">
       <div class="nav-inner">
-        <a href="/">
+        <a href="./">
           <img src="assets/remarq-wordmark-white.png" alt="Remarq" class="nav-logo" />
         </a>
         <div class="nav-links">
-          <a href="https://github.com/cass-clearly/remarq" class="nav-link nav-link--gh">
+          <a href="https://github.com/cass-clearly/remarq" class="nav-link nav-link--gh" target="_blank" rel="noopener">
             <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor">
               <path
                 d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
@@ -461,7 +470,9 @@
           </p>
           <div class="hero-cta">
             <a href="#setup" class="btn btn--primary">Get Started</a>
-            <a href="https://github.com/cass-clearly/remarq" class="btn btn--outline">View on GitHub</a>
+            <a href="https://github.com/cass-clearly/remarq" class="btn btn--outline" target="_blank" rel="noopener"
+              >View on GitHub</a
+            >
           </div>
         </div>
       </section>
@@ -560,7 +571,9 @@ docker compose -f docker-compose.remarq.yml up --build</pre>
           </div>
 
           <p class="setup-note setup-note--docs">
-            <a href="https://github.com/cass-clearly/remarq#quick-start">Full documentation &rarr;</a>
+            <a href="https://github.com/cass-clearly/remarq#quick-start" target="_blank" rel="noopener"
+              >Full documentation &rarr;</a
+            >
           </p>
         </div>
       </section>
@@ -570,9 +583,11 @@ docker compose -f docker-compose.remarq.yml up --build</pre>
     <footer class="footer">
       <div class="footer-inner">
         <div class="footer-links">
-          <a href="https://github.com/cass-clearly/remarq">GitHub</a>
-          <a href="https://github.com/cass-clearly/remarq#api-reference">API Docs</a>
-          <a href="https://github.com/cass-clearly/remarq/blob/main/LICENSE">AGPL-3.0 + Commercial</a>
+          <a href="https://github.com/cass-clearly/remarq" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://github.com/cass-clearly/remarq#api-reference" target="_blank" rel="noopener">API Docs</a>
+          <a href="https://github.com/cass-clearly/remarq/blob/main/LICENSE" target="_blank" rel="noopener"
+            >AGPL-3.0 + Commercial</a
+          >
         </div>
         <p>Open source. Self-hosted. Google Docs can keep its broken comment threads.</p>
       </div>


### PR DESCRIPTION
## What changed

Three fixes to the landing page based on Council Steward review of PR #238:

1. **Nav logo href** — changed from `/` to `./` so it works correctly on GitHub Pages (`cass-clearly.github.io/remarq/`)
2. **`prefers-reduced-motion`** — added media query to respect OS-level reduced motion preferences (accessibility regression from #238)
3. **External links** — added `target="_blank" rel="noopener"` to all external links (GitHub, API Docs, License) so visitors don't lose the landing page

## Why

PR #238 was merged before the Steward's Round 3 review completed. These are the three changes The Steward requested — all legitimate production/accessibility/UX issues.

## How to verify

1. `npm run lint && npm run format:check` — clean
2. Open `docs/index.html` in browser:
   - Click logo → stays on page (not broken `/` redirect)
   - External links open in new tabs
   - Set `prefers-reduced-motion: reduce` in OS → transitions are instant

## Manual testing checklist

- [x] Existing tests pass (`npm test`)
- [x] Lint and format pass
- [x] No console errors in browser DevTools
- [x] Logo link works correctly
- [x] External links open in new tabs