### PR TITLE
style: fix prettier formatting in docs/index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -654,7 +654,10 @@
                 </svg>
               </div>
               <h3>Zero Friction</h3>
-              <p>~4 KB client with no backend dependency. Drop it on static sites, staging servers, or localhost. Nothing to configure — it just works.</p>
+              <p>
+                ~4 KB client with no backend dependency. Drop it on static sites, staging servers, or localhost. Nothing
+                to configure — it just works.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes CI failure from #242 merge — one long paragraph line in the social proof section was not formatted by Prettier.