### PR TITLE
docs: GitHub Action README polish + example output (REM-28)

### DIFF
--- a/github-action/README.md
+++ b/github-action/README.md
@@ -91,25 +91,13 @@ That's it. Three inputs, one secret, zero config files.
 
 ## Example Review Output
 
-When Claude finds issues in your docs, review comments appear inline on the PR diff:
+Review comments appear as standard GitHub PR inline comments, anchored to the specific diff lines where issues were found — just like comments from a human reviewer. Each comment body uses the format:
 
-```
-📝 github-action/README.md
+> **suggestion:** Missing prerequisite — readers need to know they should have Node.js 20+ installed before running npm install. Add a note or link to the Requirements section.
 
-  Line 42:
-  > "Run `npm install` to install dependencies"
-  💡 suggestion: Missing prerequisite — readers need to know they should have
-     Node.js 20+ installed before running npm install. Add a note or link to
-     the Requirements section.
+> **warning:** This contradicts the Quick Start section above, which passes the key via the `anthropic-api-key` input. Readers will be confused about which method to use. Remove or clarify.
 
-  Line 87:
-  > "Set the `ANTHROPIC_API_KEY` environment variable"
-  ⚠️ warning: This contradicts the Quick Start section above, which passes the
-     key via `anthropic-api-key` input. Readers will be confused about which
-     method to use. Remove or clarify.
-```
-
-If Claude returns no issues for a file, nothing is posted — zero noise.
+All comments for a PR are posted as a single review batch. If Claude finds no issues, nothing is posted — zero noise.
 
 ## What Claude Reviews For
 


### PR DESCRIPTION
## What changed

- Added example review output section to `github-action/README.md` showing what inline review comments look like in practice (a suggestion and a warning)
- Verified dist bundle is current (rebuild produced identical output)
- Confirmed all 49 github-action tests pass at 100% line coverage

## Why

REM-28 requested: "Finalize README with real example output (actual review comment screenshot or markdown example)". The other items in REM-28 (PR diff fetching, file pattern filtering, multi-file review loop, wiring) were already implemented in the walking skeleton (REM-27).

**Publish blocker:** The README and action examples reference `cass-clearly/remarq-action@v1`, but the action code lives in `cass-clearly/remarq/github-action/`. GitHub Actions doesn't support subdirectory references natively. Options:
1. Create a separate `remarq-action` repo (sync or mirror the `github-action/` dir)
2. Move `action.yml` to the repo root (conflicts with main project structure)

This needs a decision before tagging v1.0.0. Filed as a note — not blocking the README polish.

## How to verify

```bash
cd github-action && npm test
```

49/49 tests pass. README example output is representative of actual review comment format.

## Manual testing checklist

- [x] Existing tests pass (`npm test` — 49/49)
- [x] Coverage thresholds met (100% lines)
- [x] Lint + format pass
- [x] dist/ bundle verified current