### PR TITLE
docs: add product filter framework (6 questions before building anything)

### DIFF
--- a/docs/PRODUCT_FILTER.md
+++ b/docs/PRODUCT_FILTER.md
@@ -12,11 +12,11 @@ Jobs called it "hair on fire." Musk asks if removing the problem meaningfully ad
 
 If the customer can ignore the problem and be fine, walk away. Nice-to-haves are where roadmaps go to die.
 
-> **For Remarq:** Does the reviewer *actually* find the current feedback process painful, or do they just accept it? Are authors genuinely losing signal in their feedback loops, or just mildly inconvenienced?
+> **For Remarq:** Does the reviewer _actually_ find the current feedback process painful, or do they just accept it? Are authors genuinely losing signal in their feedback loops, or just mildly inconvenienced?
 
 ---
 
-### 2. What changed that makes this possible *now*?
+### 2. What changed that makes this possible _now_?
 
 Every great business is built on a shift — a new technology, a behavior change, a regulation, a demographic tipping point.
 
@@ -30,7 +30,7 @@ If the answer is "nothing changed, it was always a good idea," that's a red flag
 
 Musk's first-principles framing: assume human behavior is a constant. If your product only works if people behave differently, the physics are against you.
 
-The best products work *with* existing behavior and remove friction from what people already do.
+The best products work _with_ existing behavior and remove friction from what people already do.
 
 > **For Remarq:** Are we asking reviewers to learn a new workflow, or are we inserting ourselves into the workflow they already have? The latter is the right answer.
 
@@ -88,4 +88,4 @@ Before committing to any significant product bet, answer these:
 
 ---
 
-*Added to capture the product thinking framework used to evaluate Remarq's own trajectory. See also: [JTBD.md](./JTBD.md), [PRINCIPLES.md](../PRINCIPLES.md).*
+_Added to capture the product thinking framework used to evaluate Remarq's own trajectory. See also: [JTBD.md](./JTBD.md), [PRINCIPLES.md](../PRINCIPLES.md)._

--- a/docs/PRODUCT_FILTER.md
+++ b/docs/PRODUCT_FILTER.md
@@ -1,0 +1,91 @@
+# Product Filter — Is This Worth Building?
+
+These questions come from how elite founders think about new initiatives — distilled from the mental models of builders like Tobi Lütke, Steve Jobs, and Elon Musk. Apply them before adding a feature, scoping a roadmap item, or making a significant product bet.
+
+---
+
+## The Six Questions
+
+### 1. Is the pain real and acute — or just a nuance?
+
+Jobs called it "hair on fire." Musk asks if removing the problem meaningfully advances civilization. Tobi asks if merchants lose sleep over it.
+
+If the customer can ignore the problem and be fine, walk away. Nice-to-haves are where roadmaps go to die.
+
+> **For Remarq:** Does the reviewer *actually* find the current feedback process painful, or do they just accept it? Are authors genuinely losing signal in their feedback loops, or just mildly inconvenienced?
+
+---
+
+### 2. What changed that makes this possible *now*?
+
+Every great business is built on a shift — a new technology, a behavior change, a regulation, a demographic tipping point.
+
+If the answer is "nothing changed, it was always a good idea," that's a red flag. Timing isn't luck; it's a precondition.
+
+> **For Remarq:** What's the enabling shift? (LLMs making agent-consumable feedback valuable, teams moving async-first, docs-as-code becoming default.) If the answer isn't crisp, the feature might be premature.
+
+---
+
+### 3. Does it require people to change behavior?
+
+Musk's first-principles framing: assume human behavior is a constant. If your product only works if people behave differently, the physics are against you.
+
+The best products work *with* existing behavior and remove friction from what people already do.
+
+> **For Remarq:** Are we asking reviewers to learn a new workflow, or are we inserting ourselves into the workflow they already have? The latter is the right answer.
+
+---
+
+### 4. What's the distribution strategy?
+
+A great product with no path to customers is a hobby. All three founders obsess over this.
+
+How does this spread? Who finds it? Why does the first customer tell the second? If you can't answer clearly, the product isn't ready for the investment.
+
+> **For Remarq:** Who is the first customer for this feature? How do they tell the next team? Is there a viral loop (e.g., reviewers become authors, authors embed Remarq, their readers become reviewers)?
+
+---
+
+### 5. Can you be the only person who should build this?
+
+Tobi calls this "earned secrets" — insights you have that others don't because of your specific experience. Jobs called it the intersection of deep craft and mass market.
+
+If anyone could build it equally well, why you? If the answer is "no one else has thought of it yet," that's not an answer — it's a countdown.
+
+> **For Remarq:** What's our unfair advantage here? Domain knowledge of agent/LLM feedback loops, the existing MCP integration, the document annotation substrate? Or is this just table stakes someone else will ship next quarter?
+
+---
+
+### 6. Is it important?
+
+Musk's filter is almost embarrassingly simple: does this matter? Jobs asked "will this change the world?" Tobi asks if it makes commerce more fair.
+
+Reject clever but inconsequential. Ship small, but ship things that matter.
+
+> **For Remarq:** If this feature works perfectly, who does it help and how much? Is it a 2x improvement on an important workflow, or a 10% improvement on a marginal one?
+
+---
+
+## The Final Question
+
+> **"Would you still be building this in 10 years if you weren't making money?"**
+
+That's not romanticism — it's a selection filter for the obsession that lets you outcompete everyone doing it for rational reasons. If the answer is no, be honest about what that means for prioritization.
+
+---
+
+## Quick Checklist
+
+Before committing to any significant product bet, answer these:
+
+- [ ] The pain is acute, not just present
+- [ ] There's a clear "why now" — something changed that enables this
+- [ ] It works with existing user behavior, not against it
+- [ ] We know how it spreads and who sells it
+- [ ] We have an earned advantage, not just a head start
+- [ ] If it succeeds, it matters — not just to our metrics, but to someone's life or work
+- [ ] We'd build it even if it were slow and hard and not obviously winning
+
+---
+
+*Added to capture the product thinking framework used to evaluate Remarq's own trajectory. See also: [JTBD.md](./JTBD.md), [PRINCIPLES.md](../PRINCIPLES.md).*


### PR DESCRIPTION
## What

Adds `docs/PRODUCT_FILTER.md` — a set of six questions to apply before committing to any significant feature or product bet.

## Why

Distilled from the decision-making frameworks of Tobi Lütke, Steve Jobs, and Elon Musk, applied specifically to Remarq's context. The goal is to encode *how we decide what to build* — not just *what to build*.

## The Six Questions

1. **Is the pain real and acute** — or just a nuance? (Jobs: hair on fire)
2. **What changed that makes this possible now?** — timing isn't luck, it's a precondition
3. **Does it require behavior change?** — work with existing behavior, not against it
4. **What's the distribution strategy?** — great product + no path to customers = hobby
5. **Can you be the only person who should build this?** — earned secrets, not just head start
6. **Is it important?** — reject clever but inconsequential

Each question is framed against Remarq's specific product context.

## Pairs With

- `docs/JTBD.md`
- `PRINCIPLES.md`