### PR TITLE
feat: cursor-based pagination for GET /comments (#263)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -343,9 +343,7 @@ app.get(
         [status],
       ));
     } else {
-      ({ rows } = await pool.query(
-        `SELECT * FROM comments ORDER BY created_at ASC, id ASC${limitClause}`,
-      ));
+      ({ rows } = await pool.query(`SELECT * FROM comments ORDER BY created_at ASC, id ASC${limitClause}`));
     }
 
     // Determine next cursor

--- a/server/index.js
+++ b/server/index.js
@@ -126,8 +126,21 @@ function formatComment(row) {
   };
 }
 
-function listResponse(items) {
-  return { object: "list", data: items };
+function listResponse(items, extra) {
+  return { object: "list", data: items, ...extra };
+}
+
+// Encode/decode an opaque cursor for the comments endpoint.
+// Cursor encodes { offset } — offset into the ordered result set.
+function encodeCursor(offset) {
+  return Buffer.from(JSON.stringify({ offset })).toString("base64url");
+}
+function decodeCursor(cursor) {
+  try {
+    return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
 }
 function errorResponse(msg) {
   return { error: { message: msg } };
@@ -250,10 +263,35 @@ app.delete(
 app.get(
   "/comments",
   asyncHandler(async (req, res) => {
-    const { document: docId, uri, status, expand } = req.query;
+    const { document: docId, uri, status, expand, after, limit: limitParam } = req.query;
 
     if (status !== undefined && status !== "open" && status !== "closed") {
       return res.status(400).json(errorResponse('status must be "open" or "closed"'));
+    }
+
+    // Pagination params — only active when limit is provided explicitly.
+    // Default: no pagination (return all, backward compatible).
+    let paginated = false;
+    let limit = null;
+    let afterId = null;
+
+    if (limitParam !== undefined) {
+      const parsedLimit = parseInt(limitParam, 10);
+      if (isNaN(parsedLimit) || parsedLimit < 1 || parsedLimit > 200) {
+        return res.status(400).json(errorResponse("limit must be an integer between 1 and 200"));
+      }
+      paginated = true;
+      limit = parsedLimit;
+    }
+
+    if (after !== undefined) {
+      const decoded = decodeCursor(after);
+      if (!decoded || typeof decoded.offset !== "number") {
+        return res.status(400).json(errorResponse("invalid cursor value for 'after'"));
+      }
+      afterId = decoded.offset; // reusing afterId as offset number
+      paginated = true;
+      if (limit === null) limit = 50; // default when only cursor is provided
     }
 
     let resolvedDocId;
@@ -272,31 +310,49 @@ app.get(
       resolvedDocId = docResult.rows[0].id;
     }
 
+    // Determine offset for cursor-based pagination.
+    // afterId is reused to hold the numeric offset from the decoded cursor.
+    const offset = paginated && afterId !== null ? afterId : 0;
+
     let rows;
+    // Fetch limit+1 rows (or all rows if not paginated) to detect next page.
+    const fetchLimit = paginated ? limit + 1 : null;
+    const limitClause = fetchLimit ? ` LIMIT ${fetchLimit} OFFSET ${offset}` : "";
+
     if (resolvedDocId) {
       if (status) {
         ({ rows } = await pool.query(
           `SELECT * FROM comments WHERE document = $1
           AND ((parent IS NULL AND status = $2)
             OR (parent IN (SELECT id FROM comments WHERE document = $1 AND parent IS NULL AND status = $2)))
-          ORDER BY created_at ASC`,
+          ORDER BY created_at ASC, id ASC${limitClause}`,
           [resolvedDocId, status],
         ));
       } else {
-        ({ rows } = await pool.query("SELECT * FROM comments WHERE document = $1 ORDER BY created_at ASC", [
-          resolvedDocId,
-        ]));
+        ({ rows } = await pool.query(
+          `SELECT * FROM comments WHERE document = $1 ORDER BY created_at ASC, id ASC${limitClause}`,
+          [resolvedDocId],
+        ));
       }
     } else if (status) {
       ({ rows } = await pool.query(
         `SELECT * FROM comments
         WHERE (parent IS NULL AND status = $1)
           OR (parent IN (SELECT id FROM comments WHERE parent IS NULL AND status = $1))
-        ORDER BY created_at ASC`,
+        ORDER BY created_at ASC, id ASC${limitClause}`,
         [status],
       ));
     } else {
-      ({ rows } = await pool.query("SELECT * FROM comments ORDER BY created_at ASC"));
+      ({ rows } = await pool.query(
+        `SELECT * FROM comments ORDER BY created_at ASC, id ASC${limitClause}`,
+      ));
+    }
+
+    // Determine next cursor
+    let nextCursor = null;
+    if (paginated && rows.length > limit) {
+      rows = rows.slice(0, limit);
+      nextCursor = encodeCursor(offset + limit);
     }
 
     let data = rows.map(formatComment);
@@ -315,7 +371,8 @@ app.get(
       }
     }
 
-    res.json(listResponse(data));
+    const extra = paginated ? { next_cursor: nextCursor } : {};
+    res.json(listResponse(data, extra));
   }),
 );
 

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -271,13 +271,15 @@ const spec = {
           {
             name: "limit",
             in: "query",
-            description: "Maximum number of comments to return (1–200). When omitted, all comments are returned (backward-compatible).",
+            description:
+              "Maximum number of comments to return (1–200). When omitted, all comments are returned (backward-compatible).",
             schema: { type: "integer", minimum: 1, maximum: 200 },
           },
           {
             name: "after",
             in: "query",
-            description: "Opaque cursor returned as next_cursor in a previous paginated response. Used to fetch the next page.",
+            description:
+              "Opaque cursor returned as next_cursor in a previous paginated response. Used to fetch the next page.",
             schema: { type: "string" },
           },
         ],

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -268,11 +268,33 @@ const spec = {
           { name: "uri", in: "query", schema: { type: "string" } },
           { name: "status", in: "query", schema: { type: "string", enum: ["open", "closed"] } },
           { name: "expand", in: "query", schema: { type: "string", enum: ["document"] } },
+          {
+            name: "limit",
+            in: "query",
+            description: "Maximum number of comments to return (1–200). When omitted, all comments are returned (backward-compatible).",
+            schema: { type: "integer", minimum: 1, maximum: 200 },
+          },
+          {
+            name: "after",
+            in: "query",
+            description: "Opaque cursor returned as next_cursor in a previous paginated response. Used to fetch the next page.",
+            schema: { type: "string" },
+          },
         ],
         responses: {
           200: {
             description: "List of comments",
-            content: jsonContent(listResponse(commentSchema)),
+            content: jsonContent({
+              ...listResponse(commentSchema),
+              properties: {
+                ...listResponse(commentSchema).properties,
+                next_cursor: {
+                  type: "string",
+                  nullable: true,
+                  description: "Cursor to pass as 'after' to fetch the next page. Null when no more pages.",
+                },
+              },
+            }),
           },
           400: { description: "Bad request", content: jsonContent(errorSchema) },
         },

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -1150,6 +1150,97 @@ describe("API", async () => {
     });
   });
 
+  describe("GET /comments cursor pagination", () => {
+    it("returns all comments without limit (backward compatible)", async () => {
+      const uri = "https://example.com/pagination-test-all";
+      for (let i = 0; i < 3; i++) {
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri, quote: `q${i}`, body: `body ${i}`, author: "tester" }),
+        });
+      }
+      const res = await fetch(`${BASE}/comments?uri=${encodeURIComponent(uri)}`);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.object, "list");
+      assert.ok(json.data.length >= 3);
+      assert.equal(json.next_cursor, undefined, "no next_cursor without limit");
+    });
+
+    it("returns paginated results with limit", async () => {
+      const uri = "https://example.com/pagination-test-limit";
+      for (let i = 0; i < 5; i++) {
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri, quote: `q${i}`, body: `body ${i}`, author: "tester" }),
+        });
+      }
+      const res = await fetch(`${BASE}/comments?uri=${encodeURIComponent(uri)}&limit=2`);
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.data.length, 2);
+      assert.ok(json.next_cursor, "should return next_cursor when more pages exist");
+    });
+
+    it("fetches next page via cursor", async () => {
+      const uri = "https://example.com/pagination-test-cursor";
+      const ids = [];
+      for (let i = 0; i < 4; i++) {
+        const r = await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri, quote: `q${i}`, body: `body ${i}`, author: "tester" }),
+        });
+        const c = await r.json();
+        ids.push(c.id);
+      }
+      const page1 = await (await fetch(`${BASE}/comments?uri=${encodeURIComponent(uri)}&limit=2`)).json();
+      assert.equal(page1.data.length, 2);
+      assert.ok(page1.next_cursor);
+
+      const page2 = await (
+        await fetch(`${BASE}/comments?uri=${encodeURIComponent(uri)}&limit=2&after=${page1.next_cursor}`)
+      ).json();
+      assert.equal(page2.data.length, 2);
+      // No overlap between pages
+      const page1Ids = new Set(page1.data.map((c) => c.id));
+      for (const c of page2.data) assert.ok(!page1Ids.has(c.id), "pages must not overlap");
+    });
+
+    it("last page has null next_cursor", async () => {
+      const uri = "https://example.com/pagination-test-last";
+      for (let i = 0; i < 3; i++) {
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri, quote: `q${i}`, body: `body ${i}`, author: "tester" }),
+        });
+      }
+      const page1 = await (await fetch(`${BASE}/comments?uri=${encodeURIComponent(uri)}&limit=2`)).json();
+      const page2 = await (
+        await fetch(`${BASE}/comments?uri=${encodeURIComponent(uri)}&limit=2&after=${page1.next_cursor}`)
+      ).json();
+      assert.equal(page2.next_cursor, null, "last page should have null next_cursor");
+    });
+
+    it("returns 400 for invalid limit", async () => {
+      const res = await fetch(`${BASE}/comments?uri=https://x.com/p&limit=0`);
+      assert.equal(res.status, 400);
+    });
+
+    it("returns 400 for limit > 200", async () => {
+      const res = await fetch(`${BASE}/comments?uri=https://x.com/p&limit=201`);
+      assert.equal(res.status, 400);
+    });
+
+    it("returns 400 for invalid cursor", async () => {
+      const res = await fetch(`${BASE}/comments?uri=https://x.com/p&after=notvalidcursor`);
+      assert.equal(res.status, 400);
+    });
+  });
+
   describe("PATCH /comments/:id reply guards", () => {
     it("returns 400 when setting status on a reply", async () => {
       const parent = await (


### PR DESCRIPTION
## Summary
Adds optional cursor-based pagination to the `GET /comments` endpoint.

## Changes
- New query params: `limit` (1–200) and `after` (opaque cursor)
- When `limit` is omitted, all results are returned (fully backward compatible)
- Response includes `next_cursor` when paginated and more pages exist; `null` on last page
- Cursor is an opaque base64url-encoded offset value
- Updated OpenAPI spec with new parameters and enriched 200 response schema
- 7 new tests covering paginated requests, cursor chaining, last-page detection, and error cases

## Breaking Changes
None — existing callers that omit `limit` get the same behavior as before.

## Testing
```
node --test server/test.mjs
```
146 tests, 0 failures.

Closes #263