### PR TITLE
Implement authentication with Okta SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Security
 
+- Added enterprise authentication mode with Okta SSO, trusted identity header support, session expiration, and WebSocket auth enforcement.
 - CORS now restricted to trusted origins via `ALLOWED_ORIGINS` env var (previously allowed all origins)
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
+## Enterprise security
+
+For internal enterprise deployments, enable Okta SSO before exposing Remarq to users. See [docs/okta-auth.md](docs/okta-auth.md).
+
 ## OpenAPI Spec
 
 The server exposes a machine-readable OpenAPI 3.0 spec at:
@@ -141,6 +145,13 @@ The spec includes `x-cli` vendor extensions that drive the CLI — every endpoin
 ## API Reference
 
 Stripe-inspired resource pattern. All responses include an `object` field. **Full documentation with request/response schemas, error codes, and curl examples: [docs/api.md](docs/api.md)**
+
+### Authentication
+
+| Method | Endpoint         | Description                |
+| ------ | ---------------- | -------------------------- |
+| `GET`  | `/login`         | Start Okta SSO             |
+| `GET`  | `/auth/callback` | Complete Okta SSO callback |
 
 ### Documents
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,16 @@ When deployed, replace with your server's URL.
 
 ## Endpoints
 
+### Authentication
+
+#### `GET /login`
+
+Redirects to Okta when enterprise authentication is enabled. Returns `204 No Content` when auth is disabled.
+
+#### `GET /auth/callback`
+
+Completes the Okta authorization-code callback and sets the `remarq_session` HTTP-only cookie.
+
 ### Health Check
 
 #### `GET /health`

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,9 +58,41 @@ When deployed, replace with your server's URL.
 
 Redirects to Okta when enterprise authentication is enabled. Returns `204 No Content` when auth is disabled.
 
+**Status Codes:**
+
+- `204 No Content` — Authentication disabled
+- `302 Found` — Redirect to Okta authorization endpoint and set `remarq_oauth_state`
+- `500 Internal Server Error` — Authentication is required but neither Okta nor a trusted header is configured
+
+**Example:**
+
+```bash
+curl -i https://remarq.internal.example.com/login
+```
+
 #### `GET /auth/callback`
 
 Completes the Okta authorization-code callback and sets the `remarq_session` HTTP-only cookie.
+
+**Query Parameters:**
+
+| Name    | Required | Description                   |
+| ------- | -------- | ----------------------------- |
+| `code`  | yes      | Okta authorization code       |
+| `state` | yes      | Must match OAuth state cookie |
+
+**Status Codes:**
+
+- `302 Found` — Session cookie issued and browser redirected
+- `400 Bad Request` — Missing/invalid code or state
+- `500 Internal Server Error` — Auth configuration or Okta exchange failure
+
+**Example:**
+
+```bash
+curl -i 'https://remarq.internal.example.com/auth/callback?code=abc&state=xyz' \
+  -H 'Cookie: remarq_oauth_state=xyz'
+```
 
 ### Health Check
 

--- a/docs/okta-auth.md
+++ b/docs/okta-auth.md
@@ -2,6 +2,14 @@
 
 Remarq can require Okta SSO before serving the UI or API.
 
+## Okta application setup
+
+Create an Okta OIDC application with:
+
+- Authorization Code flow enabled
+- Redirect URI exactly matching `OKTA_REDIRECT_URI`
+- Scopes: `openid profile email`
+
 ## Required configuration
 
 Set these environment variables in production:
@@ -13,6 +21,8 @@ OKTA_CLIENT_ID=...
 OKTA_CLIENT_SECRET=...
 OKTA_REDIRECT_URI=https://remarq.internal.example.com/auth/callback
 REMARQ_SESSION_TIMEOUT_MINUTES=480
+REMARQ_POST_LOGIN_REDIRECT=/
+OKTA_TIMEOUT_MS=10000
 ```
 
 When authentication is enabled:
@@ -46,5 +56,3 @@ curl -i https://remarq.internal.example.com/login
 # HTTP/1.1 302 Found
 # Location: https://your-org.okta.com/oauth2/default/v1/authorize?...
 ```
-
-Closes #275.

--- a/docs/okta-auth.md
+++ b/docs/okta-auth.md
@@ -1,0 +1,50 @@
+# Okta authentication
+
+Remarq can require Okta SSO before serving the UI or API.
+
+## Required configuration
+
+Set these environment variables in production:
+
+```bash
+REMARQ_AUTH_REQUIRED=true
+OKTA_ISSUER=https://your-org.okta.com/oauth2/default
+OKTA_CLIENT_ID=...
+OKTA_CLIENT_SECRET=...
+OKTA_REDIRECT_URI=https://remarq.internal.example.com/auth/callback
+REMARQ_SESSION_TIMEOUT_MINUTES=480
+```
+
+When authentication is enabled:
+
+- anonymous UI and API requests return `401 Authentication required`
+- `/login` redirects to Okta using the authorization-code flow
+- `/auth/callback` exchanges the code for an Okta access token and reads `/userinfo`
+- a secure, HTTP-only `remarq_session` cookie is issued
+- sessions expire after `REMARQ_SESSION_TIMEOUT_MINUTES`
+
+`/health`, `/login`, `/auth/callback`, and `/openapi.json` remain public for operations and discovery.
+
+## Reverse proxy mode
+
+If a corporate proxy already terminates Okta SSO, set:
+
+```bash
+REMARQ_AUTH_REQUIRED=true
+REMARQ_TRUSTED_AUTH_HEADER=X-Forwarded-User
+```
+
+Only use this behind a trusted internal proxy that strips inbound client-supplied copies of that header.
+
+## Verification
+
+```bash
+curl -i https://remarq.internal.example.com/comments
+# HTTP/1.1 401 Unauthorized
+
+curl -i https://remarq.internal.example.com/login
+# HTTP/1.1 302 Found
+# Location: https://your-org.okta.com/oauth2/default/v1/authorize?...
+```
+
+Closes #275.

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,12 +1,27 @@
 const crypto = require("crypto");
 
 const DEFAULT_SESSION_TIMEOUT_MS = 8 * 60 * 60 * 1000;
-const PUBLIC_PATHS = new Set(["/health", "/login", "/auth/callback", "/openapi.json"]);
+const DEFAULT_OKTA_TIMEOUT_MS = 10000;
+const PUBLIC_PATHS = new Set(["/health", "/login", "/auth/callback"]);
 
 function isAuthRequired(env = process.env) {
   return (
     env.REMARQ_AUTH_REQUIRED === "true" || Boolean(env.OKTA_ISSUER && env.OKTA_CLIENT_ID && env.OKTA_CLIENT_SECRET)
   );
+}
+
+function hasOktaConfig(env = process.env) {
+  return Boolean(env.OKTA_ISSUER && env.OKTA_CLIENT_ID && env.OKTA_CLIENT_SECRET && env.OKTA_REDIRECT_URI);
+}
+
+function hasTrustedHeaderConfig(env = process.env) {
+  return Boolean(env.REMARQ_TRUSTED_AUTH_HEADER);
+}
+
+function authConfigError(env = process.env) {
+  if (!isAuthRequired(env)) return null;
+  if (hasOktaConfig(env) || hasTrustedHeaderConfig(env)) return null;
+  return "Authentication requires Okta settings or REMARQ_TRUSTED_AUTH_HEADER";
 }
 
 function sessionTimeoutMs(env = process.env) {
@@ -15,16 +30,25 @@ function sessionTimeoutMs(env = process.env) {
 }
 
 function parseCookies(header = "") {
-  return Object.fromEntries(
-    header
-      .split(";")
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .map((part) => {
-        const index = part.indexOf("=");
-        return [part.slice(0, index), decodeURIComponent(part.slice(index + 1))];
-      }),
-  );
+  const cookies = {};
+  for (const rawPart of header.split(";")) {
+    const part = rawPart.trim();
+    if (!part) continue;
+    const index = part.indexOf("=");
+    if (index <= 0) continue;
+    try {
+      cookies[part.slice(0, index)] = decodeURIComponent(part.slice(index + 1));
+    } catch {
+      cookies[part.slice(0, index)] = part.slice(index + 1);
+    }
+  }
+  return cookies;
+}
+
+function requestHeader(req, name) {
+  if (typeof req.get === "function") return req.get(name);
+  const lower = name.toLowerCase();
+  return req.headers?.[lower];
 }
 
 function createSessionStore() {
@@ -63,8 +87,19 @@ function oktaAuthorizeUrl(env = process.env, state) {
   return `${issuer}/v1/authorize?${params.toString()}`;
 }
 
-async function exchangeOktaCode(code, env = process.env) {
+async function fetchWithTimeout(url, options = {}, timeoutMs = DEFAULT_OKTA_TIMEOUT_MS) {
+  const controller = new globalThis.AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function exchangeOktaCode(code, env = process.env, { fetchFn = fetchWithTimeout } = {}) {
   const issuer = env.OKTA_ISSUER?.replace(/\/$/, "");
+  const timeoutMs = Number(env.OKTA_TIMEOUT_MS || DEFAULT_OKTA_TIMEOUT_MS);
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code,
@@ -72,14 +107,22 @@ async function exchangeOktaCode(code, env = process.env) {
     client_id: env.OKTA_CLIENT_ID,
     client_secret: env.OKTA_CLIENT_SECRET,
   });
-  const tokenRes = await fetch(`${issuer}/v1/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body,
-  });
+  const tokenRes = await fetchFn(
+    `${issuer}/v1/token`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    },
+    timeoutMs,
+  );
   if (!tokenRes.ok) throw new Error(`Okta token exchange failed: ${tokenRes.status}`);
   const token = await tokenRes.json();
-  const userRes = await fetch(`${issuer}/v1/userinfo`, { headers: { Authorization: `Bearer ${token.access_token}` } });
+  const userRes = await fetchFn(
+    `${issuer}/v1/userinfo`,
+    { headers: { Authorization: `Bearer ${token.access_token}` } },
+    timeoutMs,
+  );
   if (!userRes.ok) throw new Error(`Okta userinfo failed: ${userRes.status}`);
   const profile = await userRes.json();
   return {
@@ -89,30 +132,44 @@ async function exchangeOktaCode(code, env = process.env) {
   };
 }
 
+function authenticateRequest(req, { env = process.env, store = createSessionStore() } = {}) {
+  if (!isAuthRequired(env)) return { authenticated: true, user: null };
+
+  const trustedHeader = env.REMARQ_TRUSTED_AUTH_HEADER;
+  const trustedUser = trustedHeader && requestHeader(req, trustedHeader);
+  if (trustedUser) {
+    return { authenticated: true, user: { id: trustedUser, email: trustedUser, name: trustedUser } };
+  }
+
+  const cookies = parseCookies(req.headers?.cookie || "");
+  const user = cookies.remarq_session ? store.get(cookies.remarq_session) : null;
+  if (user) return { authenticated: true, user };
+  return { authenticated: false, user: null };
+}
+
 function createAuthMiddleware({ env = process.env, store = createSessionStore() } = {}) {
   return async function authMiddleware(req, res, next) {
-    if (!isAuthRequired(env) || PUBLIC_PATHS.has(req.path) || req.path.startsWith("/serve/")) return next();
-
-    const trustedUser = env.REMARQ_TRUSTED_AUTH_HEADER && req.get(env.REMARQ_TRUSTED_AUTH_HEADER);
-    if (trustedUser) {
-      req.user = { id: trustedUser, email: trustedUser, name: trustedUser };
+    if (PUBLIC_PATHS.has(req.path)) return next();
+    const configError = authConfigError(env);
+    if (configError) return res.status(500).json({ error: { message: configError } });
+    const result = authenticateRequest(req, { env, store });
+    if (result.authenticated) {
+      req.user = result.user;
       return next();
     }
-
-    const cookies = parseCookies(req.headers.cookie || "");
-    const user = cookies.remarq_session ? store.get(cookies.remarq_session) : null;
-    if (user) {
-      req.user = user;
-      return next();
-    }
-
     return res.status(401).json({ error: { message: "Authentication required" } });
   };
 }
 
-function registerAuthRoutes(app, { env = process.env, store = createSessionStore() } = {}) {
+function registerAuthRoutes(
+  app,
+  { env = process.env, store = createSessionStore(), codeExchanger = exchangeOktaCode } = {},
+) {
   app.get("/login", (req, res) => {
     if (!isAuthRequired(env)) return res.status(204).end();
+    const configError = authConfigError(env);
+    if (configError) return res.status(500).json({ error: { message: configError } });
+    if (!hasOktaConfig(env)) return res.status(404).json({ error: { message: "Okta login is not configured" } });
     const state = crypto.randomBytes(16).toString("base64url");
     res.cookie("remarq_oauth_state", state, { httpOnly: true, sameSite: "lax", secure: env.NODE_ENV === "production" });
     res.redirect(oktaAuthorizeUrl(env, state));
@@ -120,11 +177,13 @@ function registerAuthRoutes(app, { env = process.env, store = createSessionStore
 
   app.get("/auth/callback", async (req, res, next) => {
     try {
+      const configError = authConfigError(env);
+      if (configError) return res.status(500).json({ error: { message: configError } });
       const cookies = parseCookies(req.headers.cookie || "");
       if (!req.query.code || !req.query.state || req.query.state !== cookies.remarq_oauth_state) {
         return res.status(400).json({ error: { message: "Invalid Okta callback" } });
       }
-      const user = await exchangeOktaCode(req.query.code, env);
+      const user = await codeExchanger(req.query.code, env);
       const sid = store.create(user, sessionTimeoutMs(env));
       res.cookie("remarq_session", sid, {
         httpOnly: true,
@@ -141,9 +200,13 @@ function registerAuthRoutes(app, { env = process.env, store = createSessionStore
 }
 
 module.exports = {
+  authenticateRequest,
+  authConfigError,
   createAuthMiddleware,
   createSessionStore,
   exchangeOktaCode,
+  fetchWithTimeout,
+  hasOktaConfig,
   isAuthRequired,
   oktaAuthorizeUrl,
   parseCookies,

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,152 @@
+const crypto = require("crypto");
+
+const DEFAULT_SESSION_TIMEOUT_MS = 8 * 60 * 60 * 1000;
+const PUBLIC_PATHS = new Set(["/health", "/login", "/auth/callback", "/openapi.json"]);
+
+function isAuthRequired(env = process.env) {
+  return (
+    env.REMARQ_AUTH_REQUIRED === "true" || Boolean(env.OKTA_ISSUER && env.OKTA_CLIENT_ID && env.OKTA_CLIENT_SECRET)
+  );
+}
+
+function sessionTimeoutMs(env = process.env) {
+  const minutes = Number(env.REMARQ_SESSION_TIMEOUT_MINUTES || 480);
+  return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 * 1000 : DEFAULT_SESSION_TIMEOUT_MS;
+}
+
+function parseCookies(header = "") {
+  return Object.fromEntries(
+    header
+      .split(";")
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => {
+        const index = part.indexOf("=");
+        return [part.slice(0, index), decodeURIComponent(part.slice(index + 1))];
+      }),
+  );
+}
+
+function createSessionStore() {
+  const sessions = new Map();
+  return {
+    create(user, timeoutMs = DEFAULT_SESSION_TIMEOUT_MS) {
+      const id = crypto.randomBytes(32).toString("base64url");
+      sessions.set(id, { user, expiresAt: Date.now() + timeoutMs });
+      return id;
+    },
+    get(id) {
+      const session = sessions.get(id);
+      if (!session) return null;
+      if (session.expiresAt <= Date.now()) {
+        sessions.delete(id);
+        return null;
+      }
+      return session.user;
+    },
+    delete(id) {
+      sessions.delete(id);
+    },
+  };
+}
+
+function oktaAuthorizeUrl(env = process.env, state) {
+  const issuer = env.OKTA_ISSUER?.replace(/\/$/, "");
+  const redirectUri = env.OKTA_REDIRECT_URI;
+  const params = new URLSearchParams({
+    client_id: env.OKTA_CLIENT_ID,
+    response_type: "code",
+    scope: "openid profile email",
+    redirect_uri: redirectUri,
+    state,
+  });
+  return `${issuer}/v1/authorize?${params.toString()}`;
+}
+
+async function exchangeOktaCode(code, env = process.env) {
+  const issuer = env.OKTA_ISSUER?.replace(/\/$/, "");
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: env.OKTA_REDIRECT_URI,
+    client_id: env.OKTA_CLIENT_ID,
+    client_secret: env.OKTA_CLIENT_SECRET,
+  });
+  const tokenRes = await fetch(`${issuer}/v1/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!tokenRes.ok) throw new Error(`Okta token exchange failed: ${tokenRes.status}`);
+  const token = await tokenRes.json();
+  const userRes = await fetch(`${issuer}/v1/userinfo`, { headers: { Authorization: `Bearer ${token.access_token}` } });
+  if (!userRes.ok) throw new Error(`Okta userinfo failed: ${userRes.status}`);
+  const profile = await userRes.json();
+  return {
+    id: profile.sub,
+    email: profile.email,
+    name: profile.name || profile.preferred_username || profile.email || profile.sub,
+  };
+}
+
+function createAuthMiddleware({ env = process.env, store = createSessionStore() } = {}) {
+  return async function authMiddleware(req, res, next) {
+    if (!isAuthRequired(env) || PUBLIC_PATHS.has(req.path) || req.path.startsWith("/serve/")) return next();
+
+    const trustedUser = env.REMARQ_TRUSTED_AUTH_HEADER && req.get(env.REMARQ_TRUSTED_AUTH_HEADER);
+    if (trustedUser) {
+      req.user = { id: trustedUser, email: trustedUser, name: trustedUser };
+      return next();
+    }
+
+    const cookies = parseCookies(req.headers.cookie || "");
+    const user = cookies.remarq_session ? store.get(cookies.remarq_session) : null;
+    if (user) {
+      req.user = user;
+      return next();
+    }
+
+    return res.status(401).json({ error: { message: "Authentication required" } });
+  };
+}
+
+function registerAuthRoutes(app, { env = process.env, store = createSessionStore() } = {}) {
+  app.get("/login", (req, res) => {
+    if (!isAuthRequired(env)) return res.status(204).end();
+    const state = crypto.randomBytes(16).toString("base64url");
+    res.cookie("remarq_oauth_state", state, { httpOnly: true, sameSite: "lax", secure: env.NODE_ENV === "production" });
+    res.redirect(oktaAuthorizeUrl(env, state));
+  });
+
+  app.get("/auth/callback", async (req, res, next) => {
+    try {
+      const cookies = parseCookies(req.headers.cookie || "");
+      if (!req.query.code || !req.query.state || req.query.state !== cookies.remarq_oauth_state) {
+        return res.status(400).json({ error: { message: "Invalid Okta callback" } });
+      }
+      const user = await exchangeOktaCode(req.query.code, env);
+      const sid = store.create(user, sessionTimeoutMs(env));
+      res.cookie("remarq_session", sid, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: env.NODE_ENV === "production",
+        maxAge: sessionTimeoutMs(env),
+      });
+      res.clearCookie("remarq_oauth_state");
+      res.redirect(env.REMARQ_POST_LOGIN_REDIRECT || "/");
+    } catch (err) {
+      next(err);
+    }
+  });
+}
+
+module.exports = {
+  createAuthMiddleware,
+  createSessionStore,
+  exchangeOktaCode,
+  isAuthRequired,
+  oktaAuthorizeUrl,
+  parseCookies,
+  registerAuthRoutes,
+  sessionTimeoutMs,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,7 @@ const { triggerEvent } = require("./webhooks.js");
 const { registerWebhookRoutes } = require("./webhook-routes.js");
 const path = require("path");
 const openApiSpec = require("./openapi.js");
+const { createAuthMiddleware, createSessionStore, registerAuthRoutes } = require("./auth.js");
 
 const app = express();
 const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : ["http://localhost:3333"];
@@ -27,6 +28,9 @@ app.use(
   }),
 );
 app.use(express.json());
+const authStore = createSessionStore();
+registerAuthRoutes(app, { store: authStore });
+app.use(createAuthMiddleware({ store: authStore }));
 
 const DATABASE_URL = process.env.DATABASE_URL || "postgresql://postgres@localhost/postgres";
 const pool = new Pool({ connectionString: DATABASE_URL });

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,7 @@ const { triggerEvent } = require("./webhooks.js");
 const { registerWebhookRoutes } = require("./webhook-routes.js");
 const path = require("path");
 const openApiSpec = require("./openapi.js");
-const { createAuthMiddleware, createSessionStore, registerAuthRoutes } = require("./auth.js");
+const { authenticateRequest, createAuthMiddleware, createSessionStore, registerAuthRoutes } = require("./auth.js");
 
 const app = express();
 const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : ["http://localhost:3333"];
@@ -27,10 +27,10 @@ app.use(
     crossOriginResourcePolicy: false,
   }),
 );
-app.use(express.json());
 const authStore = createSessionStore();
 registerAuthRoutes(app, { store: authStore });
 app.use(createAuthMiddleware({ store: authStore }));
+app.use(express.json());
 
 const DATABASE_URL = process.env.DATABASE_URL || "postgresql://postgres@localhost/postgres";
 const pool = new Pool({ connectionString: DATABASE_URL });
@@ -662,7 +662,14 @@ async function start(options = {}) {
   server.on("upgrade", (req, socket, head) => {
     const { pathname } = new URL(req.url, `http://${req.headers.host}`);
     if (pathname === "/ws") {
+      const result = authenticateRequest(req, { store: authStore });
+      if (!result.authenticated) {
+        socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+        socket.destroy();
+        return;
+      }
       wss.handleUpgrade(req, socket, head, (ws) => {
+        ws.user = result.user;
         handleWsConnection(ws);
       });
     } else {

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -129,6 +129,41 @@ const spec = {
   servers: [{ url: "/" }],
 
   paths: {
+    // ── Authentication ──────────────────────────────────────────────
+
+    "/login": {
+      get: {
+        operationId: "login",
+        summary: "Start Okta SSO",
+        tags: ["authentication"],
+        responses: {
+          204: { description: "Authentication disabled" },
+          302: { description: "Redirect to Okta authorization endpoint" },
+          500: { description: "Authentication configuration error", content: jsonContent(errorSchema) },
+        },
+      },
+    },
+
+    "/auth/callback": {
+      get: {
+        operationId: "authCallback",
+        summary: "Complete Okta SSO callback",
+        tags: ["authentication"],
+        parameters: [
+          { name: "code", in: "query", required: true, schema: { type: "string" } },
+          { name: "state", in: "query", required: true, schema: { type: "string" } },
+        ],
+        responses: {
+          302: { description: "Session cookie issued and browser redirected" },
+          400: { description: "Invalid callback state or missing code", content: jsonContent(errorSchema) },
+          500: {
+            description: "Authentication configuration or Okta exchange error",
+            content: jsonContent(errorSchema),
+          },
+        },
+      },
+    },
+
     // ── Health ──────────────────────────────────────────────────────
 
     "/health": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "index.js",
+    "auth.js",
     "generate-id.js",
     "normalize-uri.js",
     "sanitize.js",

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -104,6 +104,51 @@ describe("sanitize", async () => {
   });
 });
 
+describe("auth", async () => {
+  const { isAuthRequired, oktaAuthorizeUrl, parseCookies, sessionTimeoutMs, createSessionStore } =
+    await import("./auth.js");
+
+  it("requires auth when explicitly enabled", () => {
+    assert.equal(isAuthRequired({ REMARQ_AUTH_REQUIRED: "true" }), true);
+    assert.equal(isAuthRequired({}), false);
+  });
+
+  it("requires auth when Okta client settings are present", () => {
+    assert.equal(
+      isAuthRequired({ OKTA_ISSUER: "https://okta.example", OKTA_CLIENT_ID: "id", OKTA_CLIENT_SECRET: "s" }),
+      true,
+    );
+  });
+
+  it("builds Okta authorize URLs", () => {
+    const url = oktaAuthorizeUrl(
+      {
+        OKTA_ISSUER: "https://okta.example/oauth2/default/",
+        OKTA_CLIENT_ID: "client",
+        OKTA_REDIRECT_URI: "https://remarq.example/auth/callback",
+      },
+      "state123",
+    );
+    assert.equal(
+      url,
+      "https://okta.example/oauth2/default/v1/authorize?client_id=client&response_type=code&scope=openid+profile+email&redirect_uri=https%3A%2F%2Fremarq.example%2Fauth%2Fcallback&state=state123",
+    );
+  });
+
+  it("parses cookies and session timeout", () => {
+    assert.deepEqual(parseCookies("a=1; remarq_session=abc%201"), { a: "1", remarq_session: "abc 1" });
+    assert.equal(sessionTimeoutMs({ REMARQ_SESSION_TIMEOUT_MINUTES: "30" }), 30 * 60 * 1000);
+  });
+
+  it("expires sessions", async () => {
+    const store = createSessionStore();
+    const sid = store.create({ id: "u1" }, 1);
+    assert.deepEqual(store.get(sid), { id: "u1" });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    assert.equal(store.get(sid), null);
+  });
+});
+
 describe("validate-color", async () => {
   const { validateColor } = await import("./validate-color.js");
 

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -364,6 +364,137 @@ describe("API", async () => {
     });
   });
 
+  // ── Authentication ────────────────────────────────────────────
+
+  function setAuthEnv(values) {
+    const keys = [
+      "REMARQ_AUTH_REQUIRED",
+      "REMARQ_TRUSTED_AUTH_HEADER",
+      "OKTA_ISSUER",
+      "OKTA_CLIENT_ID",
+      "OKTA_CLIENT_SECRET",
+      "OKTA_REDIRECT_URI",
+    ];
+    const previous = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+    for (const key of keys) delete process.env[key];
+    Object.assign(process.env, values);
+    return () => {
+      for (const key of keys) {
+        if (previous[key] === undefined) delete process.env[key];
+        else process.env[key] = previous[key];
+      }
+    };
+  }
+
+  describe("authentication", () => {
+    it("rejects anonymous protected API requests before parsing JSON", async () => {
+      const restore = setAuthEnv({ REMARQ_AUTH_REQUIRED: "true", REMARQ_TRUSTED_AUTH_HEADER: "X-Remarq-User" });
+      try {
+        const res = await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{not json",
+        });
+        assert.equal(res.status, 401);
+        const json = await res.json();
+        assert.equal(json.error.message, "Authentication required");
+      } finally {
+        restore();
+      }
+    });
+
+    it("allows trusted-header authenticated API requests", async () => {
+      const restore = setAuthEnv({ REMARQ_AUTH_REQUIRED: "true", REMARQ_TRUSTED_AUTH_HEADER: "X-Remarq-User" });
+      try {
+        const res = await fetch(`${BASE}/comments`, { headers: { "X-Remarq-User": "alice@example.com" } });
+        assert.equal(res.status, 200);
+      } finally {
+        restore();
+      }
+    });
+
+    it("redirects login to Okta and sets oauth state", async () => {
+      const restore = setAuthEnv({
+        REMARQ_AUTH_REQUIRED: "true",
+        OKTA_ISSUER: "https://okta.example/oauth2/default",
+        OKTA_CLIENT_ID: "client",
+        OKTA_CLIENT_SECRET: "secret",
+        OKTA_REDIRECT_URI: `${BASE}/auth/callback`,
+      });
+      try {
+        const res = await fetch(`${BASE}/login`, { redirect: "manual" });
+        assert.equal(res.status, 302);
+        assert.ok(res.headers.get("set-cookie").includes("remarq_oauth_state="));
+        assert.ok(res.headers.get("location").startsWith("https://okta.example/oauth2/default/v1/authorize?"));
+      } finally {
+        restore();
+      }
+    });
+
+    it("rejects invalid Okta callback state", async () => {
+      const restore = setAuthEnv({
+        REMARQ_AUTH_REQUIRED: "true",
+        OKTA_ISSUER: "https://okta.example/oauth2/default",
+        OKTA_CLIENT_ID: "client",
+        OKTA_CLIENT_SECRET: "secret",
+        OKTA_REDIRECT_URI: `${BASE}/auth/callback`,
+      });
+      try {
+        const res = await fetch(`${BASE}/auth/callback?code=abc&state=bad`, {
+          headers: { Cookie: "remarq_oauth_state=good" },
+        });
+        assert.equal(res.status, 400);
+      } finally {
+        restore();
+      }
+    });
+
+    it("rejects anonymous WebSocket upgrades when auth is required", async () => {
+      const restore = setAuthEnv({ REMARQ_AUTH_REQUIRED: "true", REMARQ_TRUSTED_AUTH_HEADER: "X-Remarq-User" });
+      try {
+        await assert.rejects(
+          () =>
+            new Promise((resolve, reject) => {
+              const ws = new WebSocket(BASE.replace("http", "ws") + "/ws");
+              ws.on("open", () => {
+                ws.close();
+                resolve();
+              });
+              ws.on("error", reject);
+            }),
+          /401/,
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it("allows authenticated WebSocket upgrades", async () => {
+      const restore = setAuthEnv({ REMARQ_AUTH_REQUIRED: "true", REMARQ_TRUSTED_AUTH_HEADER: "X-Remarq-User" });
+      try {
+        const docRes = await fetch(`${BASE}/documents`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Remarq-User": "alice@example.com" },
+          body: JSON.stringify({ uri: "https://example.com/auth-ws" }),
+        });
+        const doc = await docRes.json();
+        const ws = new WebSocket(BASE.replace("http", "ws") + "/ws", {
+          headers: { "X-Remarq-User": "alice@example.com" },
+        });
+        try {
+          await new Promise((resolve) => ws.once("open", resolve));
+          ws.send(JSON.stringify({ type: "subscribe", documentId: doc.id }));
+          const message = await new Promise((resolve) => ws.once("message", (data) => resolve(JSON.parse(data))));
+          assert.equal(message.type, "subscribed");
+        } finally {
+          ws.close();
+        }
+      } finally {
+        restore();
+      }
+    });
+  });
+
   // ── Documents ─────────────────────────────────────────────────
 
   describe("GET /documents", () => {


### PR DESCRIPTION
## What changed

Implemented enterprise authentication support with Okta authorization-code SSO, session cookies, configurable timeout, trusted-auth-header mode, and operator docs.

## Why

Closes #275. Block Security requires no anonymous access, Okta SSO, and expiring sessions before internal integration.

## New/Changed Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/login` | Starts Okta SSO when auth is enabled. |
| `GET` | `/auth/callback` | Completes Okta callback and issues `remarq_session`. |

## How to verify

- `npm run check`
- Configure `REMARQ_AUTH_REQUIRED=true` plus `OKTA_*` vars and verify anonymous API requests return `401`.

## Manual testing checklist

- [ ] Server starts without errors (`npm run start`)
- [x] Existing tests pass (`npm test`)
- [ ] Tested in browser (annotations, sidebar, highlights work)
- [ ] Tested API changes with curl (include example commands above)
- [ ] No console errors in browser DevTools
