### PR TITLE
Support internal-network-only deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Security
 
+- Changed the default server bind host to `127.0.0.1`; set `HOST` only for private network or trusted reverse-proxy deployments.
 - CORS now restricted to trusted origins via `ALLOWED_ORIGINS` env var (previously allowed all origins)
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Or:
 ```bash
 npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
+# Binds to 127.0.0.1 by default. Set HOST only for private networks/reverse proxies.
 ```
 
 ## Enterprise security

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ echo "POSTGRES_PASSWORD=remarq" > .env
 docker compose -f docker-compose.remarq.yml up --build
 ```
 
-Backend runs on port 3333. Visit **http://localhost:3333** for the demo.
+Backend runs on port 3333 bound to localhost. Visit **http://localhost:3333** for the demo.
 
 ### 2. Add to any HTML page
 
@@ -121,6 +121,10 @@ Or:
 npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
+
+## Enterprise security
+
+Remarq should be deployed internal-network-only behind VPN/corporate ingress. See [docs/network-isolation.md](docs/network-isolation.md).
 
 ## OpenAPI Spec
 

--- a/docker-compose.remarq.yml
+++ b/docker-compose.remarq.yml
@@ -20,10 +20,11 @@ services:
       context: .
       dockerfile: server/Dockerfile
     ports:
-      - "0.0.0.0:3333:3333"
+      - "127.0.0.1:3333:3333"
     environment:
       DATABASE_URL: postgres://remarq:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres/remarq
       PORT: "3333"
+      HOST: "0.0.0.0"
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:3333}
     depends_on:
       postgres:

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -35,9 +35,9 @@ DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 
 This is ideal for local development or solo pair-writing with your AI agent.
 
-### Team / production: Docker Compose
+### Team / internal deployment: Docker Compose
 
-For teams or production deployments, Docker Compose bundles Postgres and the Remarq server together.
+For teams or internal deployments, Docker Compose bundles Postgres and the Remarq server together. Publish Remarq only on loopback/private networks and put VPN/corporate ingress in front of it; see [network isolation](network-isolation.md).
 
 ```bash
 git clone https://github.com/cass-clearly/remarq.git
@@ -59,14 +59,14 @@ The `.env` file is read automatically by Docker Compose. Use a strong, random pa
 
 ### Reverse proxy (HTTPS)
 
-In production, put Remarq behind a reverse proxy that terminates TLS.
+In production, put Remarq behind an internal reverse proxy that terminates TLS and only accepts VPN/corporate network traffic. Do not expose Remarq directly to the public internet; see [network isolation](network-isolation.md).
 
 **Nginx:**
 
 ```nginx
 server {
     listen 443 ssl;
-    server_name remarq.example.com;
+    server_name remarq.internal.example.com;
 
     ssl_certificate     /etc/letsencrypt/live/remarq.example.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/remarq.example.com/privkey.pem;
@@ -84,17 +84,17 @@ server {
 **Caddy** (automatic HTTPS):
 
 ```
-remarq.example.com {
+remarq.internal.example.com {
     reverse_proxy 127.0.0.1:3333
 }
 ```
 
-Then point your script tag at the public domain:
+Then point your script tag at the internal domain:
 
 ```html
 <script
-  src="https://remarq.example.com/feedback-layer.js"
-  data-api-url="https://remarq.example.com"
+  src="https://remarq.internal.example.com/feedback-layer.js"
+  data-api-url="https://remarq.internal.example.com"
   data-content-selector="article"
 ></script>
 ```
@@ -111,8 +111,8 @@ The `data-content-selector` attribute determines which part of the page is annot
 
 ```html
 <script
-  src="https://remarq.example.com/feedback-layer.js"
-  data-api-url="https://remarq.example.com"
+  src="https://remarq.internal.example.com/feedback-layer.js"
+  data-api-url="https://remarq.internal.example.com"
   data-content-selector="article"
 ></script>
 ```
@@ -122,8 +122,8 @@ The `data-content-selector` attribute determines which part of the page is annot
 ```html
 <!-- Target the main content area, not the sidebar or nav -->
 <script
-  src="https://remarq.example.com/feedback-layer.js"
-  data-api-url="https://remarq.example.com"
+  src="https://remarq.internal.example.com/feedback-layer.js"
+  data-api-url="https://remarq.internal.example.com"
   data-content-selector=".docs-content"
 ></script>
 ```
@@ -132,8 +132,8 @@ The `data-content-selector` attribute determines which part of the page is annot
 
 ```html
 <script
-  src="https://remarq.example.com/feedback-layer.js"
-  data-api-url="https://remarq.example.com"
+  src="https://remarq.internal.example.com/feedback-layer.js"
+  data-api-url="https://remarq.internal.example.com"
   data-content-selector="#contract-body"
 ></script>
 ```
@@ -164,8 +164,8 @@ If you serve multiple pages from the same origin, use `data-document-uri` to giv
 
 ```html
 <script
-  src="https://remarq.example.com/feedback-layer.js"
-  data-api-url="https://remarq.example.com"
+  src="https://remarq.internal.example.com/feedback-layer.js"
+  data-api-url="https://remarq.internal.example.com"
   data-content-selector="article"
   data-document-uri="/docs/getting-started"
 ></script>
@@ -195,7 +195,7 @@ Remarq's API is designed for AI agents to consume. Here are patterns for buildin
 import requests
 import time
 
-REMARQ_URL = "https://remarq.example.com"
+REMARQ_URL = "https://remarq.internal.example.com"
 DOCUMENT_URI = "https://example.com/docs/proposal.html"
 
 def get_open_comments():
@@ -247,7 +247,7 @@ if comments:
 ### JavaScript example
 
 ```js
-const REMARQ_URL = "https://remarq.example.com";
+const REMARQ_URL = "https://remarq.internal.example.com";
 const DOCUMENT_URI = "https://example.com/docs/proposal.html";
 
 async function getOpenComments() {
@@ -441,7 +441,7 @@ Example prompt instruction:
 To reply as the agent:
 
 ```bash
-curl -X POST https://remarq.example.com/comments \
+curl -X POST https://remarq.internal.example.com/comments \
   -H "Content-Type: application/json" \
   -d '{
     "uri": "https://example.com/docs/proposal.html",
@@ -467,7 +467,7 @@ To delete all comments for a document:
 
 ```bash
 # Option 1: Delete the document (cascades to all its comments)
-curl -X DELETE https://remarq.example.com/documents/doc_abc123
+curl -X DELETE https://remarq.internal.example.com/documents/doc_abc123
 
 # The document will be automatically re-created when new comments are posted.
 ```
@@ -478,7 +478,7 @@ Before clearing comments, export them for your records:
 
 ```bash
 # Export all comments (including resolved) for a document
-curl "https://remarq.example.com/comments?uri=https://example.com/docs/proposal.html&expand=document" \
+curl "https://remarq.internal.example.com/comments?uri=https://example.com/docs/proposal.html&expand=document" \
   -o review-archive-2026-02-21.json
 ```
 
@@ -494,7 +494,7 @@ For global uniqueness, request a document ID from the server before embedding th
 
 ```bash
 # Create a document and get its server-generated ID
-curl -X POST https://remarq.example.com/documents \
+curl -X POST https://remarq.internal.example.com/documents \
   -H "Content-Type: application/json" \
   -d '{"uri": "https://example.com/docs/proposal-v2"}' \
   | jq -r '.id'
@@ -505,8 +505,8 @@ Then use that ID in your page:
 
 ```html
 <script
-  src="https://remarq.example.com/feedback-layer.js"
-  data-api-url="https://remarq.example.com"
+  src="https://remarq.internal.example.com/feedback-layer.js"
+  data-api-url="https://remarq.internal.example.com"
   data-content-selector="article"
   data-document-uri="doc_7f3a9b2c"
 ></script>

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -50,11 +50,12 @@ The `.env` file is read automatically by Docker Compose. Use a strong, random pa
 
 ### Environment variables
 
-| Variable            | Default                                    | Description                                 |
-| ------------------- | ------------------------------------------ | ------------------------------------------- |
-| `DATABASE_URL`      | `postgresql://postgres@localhost/postgres` | PostgreSQL connection string                |
-| `PORT`              | `3333`                                     | Port the server listens on                  |
-| `POSTGRES_PASSWORD` | _(required in Docker)_                     | Password for the bundled Postgres container |
+| Variable            | Default                                    | Description                                                  |
+| ------------------- | ------------------------------------------ | ------------------------------------------------------------ |
+| `DATABASE_URL`      | `postgresql://postgres@localhost/postgres` | PostgreSQL connection string                                 |
+| `PORT`              | `3333`                                     | Port the server listens on                                   |
+| `HOST`              | `127.0.0.1`                                | Bind host; use only loopback/private addresses in production |
+| `POSTGRES_PASSWORD` | _(required in Docker)_                     | Password for the bundled Postgres container                  |
 
 ### Reverse proxy (HTTPS)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -31,7 +31,7 @@ echo "POSTGRES_PASSWORD=a-strong-random-password" > .env
 docker compose -f docker-compose.remarq.yml up --build -d
 ```
 
-Backend runs on port 3333.
+Backend runs on port 3333 and binds to 127.0.0.1 by default. Docker Compose publishes localhost only; set HOST only for private network or trusted reverse-proxy deployments.
 
 ### npm (bring your own Postgres)
 
@@ -64,6 +64,7 @@ DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 |----------|---------|-------------|
 | `DATABASE_URL` | `postgresql://postgres@localhost/postgres` | PostgreSQL connection string |
 | `PORT` | `3333` | Port the server listens on |
+| `HOST` | `127.0.0.1` | Bind host; use only loopback/private addresses in production |
 | `POSTGRES_PASSWORD` | *(required in Docker)* | Password for the bundled Postgres container |
 
 ## API Reference

--- a/docs/network-isolation.md
+++ b/docs/network-isolation.md
@@ -13,7 +13,7 @@ Set `HOST=0.0.0.0` only inside a private container network or behind a VPN/corpo
 ## Supported architecture
 
 ```text
-User on VPN/corp network -> internal LB / reverse proxy -> Remarq -> private Postgres
+User on VPN or corporate network -> internal load balancer / reverse proxy -> Remarq -> private Postgres
 Internet -> firewall deny
 ```
 
@@ -27,14 +27,15 @@ Firewall / ingress requirements:
 ## Verification
 
 ```bash
-# On the host: should work
+# On the host: should work.
 curl http://127.0.0.1:3333/health
+# Expected: {"status":"ok"}
 
-# From outside VPN/corp network: must fail or time out
+# From outside VPN/corporate network: must fail or time out.
 curl https://remarq.internal.example.com/health
 
-# Confirm no public listener on Linux
+# Confirm no public listener on Linux.
 ss -ltnp | grep 3333
+# Passing: 127.0.0.1:3333
+# Failing: 0.0.0.0:3333 or :::3333
 ```
-
-Closes #278.

--- a/docs/network-isolation.md
+++ b/docs/network-isolation.md
@@ -1,0 +1,40 @@
+# Network isolation
+
+Remarq's supported enterprise posture is internal-network-only. Do not expose the service directly to the public internet.
+
+## Defaults
+
+- Direct server startup binds to `127.0.0.1` by default.
+- Docker Compose publishes Remarq on `127.0.0.1:3333` only.
+- Postgres remains bound to `127.0.0.1:5433` for local operator access.
+
+Set `HOST=0.0.0.0` only inside a private container network or behind a VPN/corporate reverse proxy.
+
+## Supported architecture
+
+```text
+User on VPN/corp network -> internal LB / reverse proxy -> Remarq -> private Postgres
+Internet -> firewall deny
+```
+
+Firewall / ingress requirements:
+
+- allow inbound HTTPS only from VPN or corporate CIDR ranges
+- deny all public internet sources
+- keep Postgres inaccessible except from Remarq and operators
+- terminate TLS at the internal proxy and forward only on private network paths
+
+## Verification
+
+```bash
+# On the host: should work
+curl http://127.0.0.1:3333/health
+
+# From outside VPN/corp network: must fail or time out
+curl https://remarq.internal.example.com/health
+
+# Confirm no public listener on Linux
+ss -ltnp | grep 3333
+```
+
+Closes #278.

--- a/server/index.js
+++ b/server/index.js
@@ -647,9 +647,15 @@ function handleWsConnection(ws) {
 
 // ── Start server ────────────────────────────────────────────────────
 
+function resolveListenOptions(options = {}, env = process.env) {
+  return {
+    port: options.port !== undefined ? options.port : env.PORT || 3333,
+    host: options.host || env.HOST || "127.0.0.1",
+  };
+}
+
 async function start(options = {}) {
-  const port = options.port !== undefined ? options.port : process.env.PORT || 3333;
-  const host = options.host || process.env.HOST || "127.0.0.1";
+  const { port, host } = resolveListenOptions(options);
   await initSchema();
 
   const server = http.createServer(app);
@@ -676,7 +682,10 @@ async function start(options = {}) {
 
   return new Promise((resolve) => {
     server.listen(port, host, () => {
-      console.log(`Remarq server listening on http://localhost:${port}`);
+      const address = server.address();
+      const actualHost = typeof address === "object" && address ? address.address : host;
+      const actualPort = typeof address === "object" && address ? address.port : port;
+      console.log(`Remarq server listening on http://${actualHost}:${actualPort}`);
       resolve(server);
     });
   });
@@ -689,4 +698,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { start, app, pool, initSchema };
+module.exports = { start, app, pool, initSchema, resolveListenOptions };

--- a/server/index.js
+++ b/server/index.js
@@ -649,7 +649,7 @@ function handleWsConnection(ws) {
 
 async function start(options = {}) {
   const port = options.port !== undefined ? options.port : process.env.PORT || 3333;
-  const host = options.host || "0.0.0.0";
+  const host = options.host || process.env.HOST || "127.0.0.1";
   await initSchema();
 
   const server = http.createServer(app);

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -104,6 +104,22 @@ describe("sanitize", async () => {
   });
 });
 
+describe("listen options", async () => {
+  const { resolveListenOptions } = await import("./index.js");
+
+  it("defaults to loopback", () => {
+    assert.deepEqual(resolveListenOptions({}, {}), { port: 3333, host: "127.0.0.1" });
+  });
+
+  it("allows HOST and explicit host overrides", () => {
+    assert.deepEqual(resolveListenOptions({}, { PORT: "4444", HOST: "10.0.0.5" }), { port: "4444", host: "10.0.0.5" });
+    assert.deepEqual(resolveListenOptions({ port: 0, host: "0.0.0.0" }, { PORT: "4444", HOST: "10.0.0.5" }), {
+      port: 0,
+      host: "0.0.0.0",
+    });
+  });
+});
+
 describe("validate-color", async () => {
   const { validateColor } = await import("./validate-color.js");
 


### PR DESCRIPTION
## What changed

Changed direct server default bind host to localhost, changed Docker Compose publishing to localhost, and documented internal-network-only deployment with firewall verification.

## Why

Closes #278. Block Security requires VPN/corporate-only access with no public internet exposure.

## New/Changed Endpoints

No endpoints changed.

## How to verify

- `npm run check`
- Start Remarq and verify it listens on loopback/private ingress only.

## Manual testing checklist

- [ ] Server starts without errors (`npm run start`)
- [x] Existing tests pass (`npm test`)
- [ ] Tested in browser (annotations, sidebar, highlights work)
- [ ] Tested API changes with curl (include example commands above)
- [ ] No console errors in browser DevTools
