### PR TITLE
Add audit logging for comment changes and document access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Security
 
+- Added durable audit records for comment create/update/delete events and document access, with 90-day minimum retention.
 - CORS now restricted to trusted origins via `ALLOWED_ORIGINS` env var (previously allowed all origins)
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
+## Enterprise security
+
+Audit logging is available for comment changes and document access. See [docs/audit-logging.md](docs/audit-logging.md).
+
 ## OpenAPI Spec
 
 The server exposes a machine-readable OpenAPI 3.0 spec at:
@@ -141,6 +145,12 @@ The spec includes `x-cli` vendor extensions that drive the CLI — every endpoin
 ## API Reference
 
 Stripe-inspired resource pattern. All responses include an `object` field. **Full documentation with request/response schemas, error codes, and curl examples: [docs/api.md](docs/api.md)**
+
+### Audit events
+
+| Method | Endpoint        | Description              |
+| ------ | --------------- | ------------------------ |
+| `GET`  | `/audit-events` | List newest audit events |
 
 ### Documents
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
-## Enterprise security
+## Audit logging
 
 Audit logging is available for comment changes and document access. See [docs/audit-logging.md](docs/audit-logging.md).
 
@@ -145,12 +145,6 @@ The spec includes `x-cli` vendor extensions that drive the CLI — every endpoin
 ## API Reference
 
 Stripe-inspired resource pattern. All responses include an `object` field. **Full documentation with request/response schemas, error codes, and curl examples: [docs/api.md](docs/api.md)**
-
-### Audit events
-
-| Method | Endpoint        | Description              |
-| ------ | --------------- | ------------------------ |
-| `GET`  | `/audit-events` | List newest audit events |
 
 ### Documents
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,12 +52,6 @@ When deployed, replace with your server's URL.
 
 ## Endpoints
 
-### Audit Events
-
-#### `GET /audit-events?limit=100`
-
-Lists newest audit events. Each record includes `actor`, `action`, `target`, `metadata`, and `created_at`.
-
 ### Health Check
 
 #### `GET /health`

--- a/docs/api.md
+++ b/docs/api.md
@@ -52,6 +52,12 @@ When deployed, replace with your server's URL.
 
 ## Endpoints
 
+### Audit Events
+
+#### `GET /audit-events?limit=100`
+
+Lists newest audit events. Each record includes `actor`, `action`, `target`, `metadata`, and `created_at`.
+
 ### Health Check
 
 #### `GET /health`

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -16,6 +16,21 @@ Audit events are retained for at least 90 days. `REMARQ_AUDIT_RETENTION_DAYS` ca
 ## Verification
 
 ```bash
-curl -H 'X-Remarq-User: alice' https://remarq.internal/comments/cmt_123
-psql "$DATABASE_URL" -c "select actor, action, target, created_at from audit_events order by created_at desc limit 5;"
+# Create a comment.
+COMMENT=$(curl -s -X POST http://localhost:3333/comments \
+  -H 'Content-Type: application/json' \
+  -H 'X-Remarq-User: alice@example.com' \
+  -d '{"uri":"https://example.com/audit","quote":"text","body":"hello","author":"alice"}')
+COMMENT_ID=$(echo "$COMMENT" | jq -r '.id')
+
+# Access, update, and delete it.
+curl -s -H 'X-Remarq-User: bob@example.com' "http://localhost:3333/comments/$COMMENT_ID" >/dev/null
+curl -s -X PATCH "http://localhost:3333/comments/$COMMENT_ID" \
+  -H 'Content-Type: application/json' \
+  -H 'X-Remarq-User: alice@example.com' \
+  -d '{"body":"updated"}' >/dev/null
+curl -s -X DELETE -H 'X-Remarq-User: alice@example.com' "http://localhost:3333/comments/$COMMENT_ID" >/dev/null
+
+# Verify audit rows.
+psql "$DATABASE_URL" -c "select actor, action, target, created_at from audit_events order by created_at desc limit 10;"
 ```

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -1,0 +1,30 @@
+# Audit logging
+
+Remarq writes auditable records for sensitive activity:
+
+- `comment.created`
+- `comment.updated`
+- `comment.status_changed`
+- `comment.deleted`
+- `document.accessed`
+
+Each record includes actor, action, target, metadata, and timestamp. Actor comes from `X-Remarq-User`, then `X-Forwarded-User`, then request `author`, then `anonymous`.
+
+## Retention
+
+Audit events are retained for at least 90 days. `REMARQ_AUDIT_RETENTION_DAYS` can increase retention but values below 90 are clamped to 90. Old events are purged at server start.
+
+## API
+
+| Method | Endpoint                  | Description                                      |
+| ------ | ------------------------- | ------------------------------------------------ |
+| `GET`  | `/audit-events?limit=100` | Lists newest audit events. `limit` maxes at 500. |
+
+## Verification
+
+```bash
+curl -H 'X-Remarq-User: alice' https://remarq.internal/comments/cmt_123
+curl https://remarq.internal/audit-events | jq '.data[0]'
+```
+
+Closes #279.

--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -4,7 +4,6 @@ Remarq writes auditable records for sensitive activity:
 
 - `comment.created`
 - `comment.updated`
-- `comment.status_changed`
 - `comment.deleted`
 - `document.accessed`
 
@@ -14,17 +13,9 @@ Each record includes actor, action, target, metadata, and timestamp. Actor comes
 
 Audit events are retained for at least 90 days. `REMARQ_AUDIT_RETENTION_DAYS` can increase retention but values below 90 are clamped to 90. Old events are purged at server start.
 
-## API
-
-| Method | Endpoint                  | Description                                      |
-| ------ | ------------------------- | ------------------------------------------------ |
-| `GET`  | `/audit-events?limit=100` | Lists newest audit events. `limit` maxes at 500. |
-
 ## Verification
 
 ```bash
 curl -H 'X-Remarq-User: alice' https://remarq.internal/comments/cmt_123
-curl https://remarq.internal/audit-events | jq '.data[0]'
+psql "$DATABASE_URL" -c "select actor, action, target, created_at from audit_events order by created_at desc limit 5;"
 ```
-
-Closes #279.

--- a/server/audit-log.js
+++ b/server/audit-log.js
@@ -25,21 +25,9 @@ async function recordAuditEvent(pool, { actor, action, target, metadata = {} }) 
   return rows[0];
 }
 
-function formatAuditEvent(row) {
-  return {
-    id: String(row.id),
-    object: "audit_event",
-    actor: row.actor,
-    action: row.action,
-    target: row.target,
-    metadata: row.metadata || {},
-    created_at: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
-  };
-}
-
 async function purgeAuditEvents(pool, retentionDays = 90) {
   const days = Math.max(Number(retentionDays) || 90, 90);
   await pool.query("DELETE FROM audit_events WHERE created_at < NOW() - ($1::text || ' days')::interval", [days]);
 }
 
-module.exports = { actorFromRequest, ensureAuditLogTable, formatAuditEvent, purgeAuditEvents, recordAuditEvent };
+module.exports = { actorFromRequest, ensureAuditLogTable, purgeAuditEvents, recordAuditEvent };

--- a/server/audit-log.js
+++ b/server/audit-log.js
@@ -1,0 +1,45 @@
+function actorFromRequest(req) {
+  return req.get("X-Remarq-User") || req.get("X-Forwarded-User") || req.body?.author || "anonymous";
+}
+
+async function ensureAuditLogTable(pool) {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS audit_events (
+      id         BIGSERIAL PRIMARY KEY,
+      actor      TEXT NOT NULL,
+      action     TEXT NOT NULL,
+      target     TEXT NOT NULL,
+      metadata   JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+  await pool.query("CREATE INDEX IF NOT EXISTS audit_events_created_at_idx ON audit_events (created_at)");
+  await pool.query("CREATE INDEX IF NOT EXISTS audit_events_target_idx ON audit_events (target)");
+}
+
+async function recordAuditEvent(pool, { actor, action, target, metadata = {} }) {
+  const { rows } = await pool.query(
+    "INSERT INTO audit_events (actor, action, target, metadata) VALUES ($1, $2, $3, $4) RETURNING *",
+    [actor || "anonymous", action, target, metadata],
+  );
+  return rows[0];
+}
+
+function formatAuditEvent(row) {
+  return {
+    id: String(row.id),
+    object: "audit_event",
+    actor: row.actor,
+    action: row.action,
+    target: row.target,
+    metadata: row.metadata || {},
+    created_at: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+  };
+}
+
+async function purgeAuditEvents(pool, retentionDays = 90) {
+  const days = Math.max(Number(retentionDays) || 90, 90);
+  await pool.query("DELETE FROM audit_events WHERE created_at < NOW() - ($1::text || ' days')::interval", [days]);
+}
+
+module.exports = { actorFromRequest, ensureAuditLogTable, formatAuditEvent, purgeAuditEvents, recordAuditEvent };

--- a/server/index.js
+++ b/server/index.js
@@ -15,13 +15,7 @@ const { triggerEvent } = require("./webhooks.js");
 const { registerWebhookRoutes } = require("./webhook-routes.js");
 const path = require("path");
 const openApiSpec = require("./openapi.js");
-const {
-  actorFromRequest,
-  ensureAuditLogTable,
-  formatAuditEvent,
-  purgeAuditEvents,
-  recordAuditEvent,
-} = require("./audit-log.js");
+const { actorFromRequest, ensureAuditLogTable, purgeAuditEvents, recordAuditEvent } = require("./audit-log.js");
 
 const app = express();
 const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : ["http://localhost:3333"];
@@ -214,8 +208,16 @@ app.get("/health", (_req, res) => {
 
 app.get(
   "/documents",
-  asyncHandler(async (_req, res) => {
+  asyncHandler(async (req, res) => {
     const { rows } = await pool.query("SELECT * FROM documents ORDER BY created_at ASC");
+    for (const row of rows) {
+      await recordAuditEvent(pool, {
+        actor: actorFromRequest(req),
+        action: "document.accessed",
+        target: row.id,
+        metadata: { uri: row.uri, source: "documents.list" },
+      });
+    }
     res.json(listResponse(rows.map(formatDocument)));
   }),
 );
@@ -257,17 +259,6 @@ app.delete(
     const { rows } = await pool.query("DELETE FROM documents WHERE id = $1 RETURNING *", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Document not found"));
     res.json(formatDocument(rows[0]));
-  }),
-);
-
-// ── Audit endpoints ───────────────────────────────────────────────
-
-app.get(
-  "/audit-events",
-  asyncHandler(async (req, res) => {
-    const limit = Math.min(Number(req.query.limit) || 100, 500);
-    const { rows } = await pool.query("SELECT * FROM audit_events ORDER BY created_at DESC LIMIT $1", [limit]);
-    res.json(listResponse(rows.map(formatAuditEvent)));
   }),
 );
 
@@ -332,6 +323,15 @@ app.get(
         target: resolvedDocId,
         metadata: { source: "comments.list" },
       });
+    } else {
+      for (const documentId of [...new Set(rows.map((row) => row.document))]) {
+        await recordAuditEvent(pool, {
+          actor: actorFromRequest(req),
+          action: "document.accessed",
+          target: documentId,
+          metadata: { source: "comments.list" },
+        });
+      }
     }
 
     let data = rows.map(formatComment);
@@ -498,7 +498,7 @@ app.patch(
     const formatted = formatComment(updated.rows[0]);
     await recordAuditEvent(pool, {
       actor: actorFromRequest(req),
-      action: body !== undefined || color !== undefined ? "comment.updated" : "comment.status_changed",
+      action: "comment.updated",
       target: formatted.id,
       metadata: { document: formatted.document, status: formatted.status },
     });

--- a/server/index.js
+++ b/server/index.js
@@ -270,19 +270,24 @@ app.get(
 app.delete(
   "/documents/:id",
   asyncHandler(async (req, res) => {
-    const deletedComments = await pool.query("SELECT * FROM comments WHERE document = $1", [req.params.id]);
-    await pool.query("DELETE FROM comments WHERE document = $1", [req.params.id]);
-    for (const comment of deletedComments.rows) {
-      await recordAuditEvent(pool, {
-        actor: actorFromRequest(req),
-        action: "comment.deleted",
-        target: comment.id,
-        metadata: { document: comment.document, source: "document.delete" },
-      });
-    }
-    const { rows } = await pool.query("DELETE FROM documents WHERE id = $1 RETURNING *", [req.params.id]);
-    if (rows.length === 0) return res.status(404).json(errorResponse("Document not found"));
-    res.json(formatDocument(rows[0]));
+    const deleted = await withTransaction(async (client) => {
+      const deletedComments = await client.query("DELETE FROM comments WHERE document = $1 RETURNING *", [
+        req.params.id,
+      ]);
+      const { rows } = await client.query("DELETE FROM documents WHERE id = $1 RETURNING *", [req.params.id]);
+      if (rows.length === 0) return { document: null };
+      for (const comment of deletedComments.rows) {
+        await recordAuditEvent(client, {
+          actor: actorFromRequest(req),
+          action: "comment.deleted",
+          target: comment.id,
+          metadata: { document: comment.document, source: "document.delete" },
+        });
+      }
+      return { document: rows[0] };
+    });
+    if (!deleted.document) return res.status(404).json(errorResponse("Document not found"));
+    res.json(formatDocument(deleted.document));
   }),
 );
 

--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,13 @@ const { triggerEvent } = require("./webhooks.js");
 const { registerWebhookRoutes } = require("./webhook-routes.js");
 const path = require("path");
 const openApiSpec = require("./openapi.js");
+const {
+  actorFromRequest,
+  ensureAuditLogTable,
+  formatAuditEvent,
+  purgeAuditEvents,
+  recordAuditEvent,
+} = require("./audit-log.js");
 
 const app = express();
 const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : ["http://localhost:3333"];
@@ -59,6 +66,8 @@ async function initSchema() {
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `);
+  await ensureAuditLogTable(pool);
+
   await pool.query(`
     CREATE TABLE IF NOT EXISTS reactions (
       comment_id TEXT NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
@@ -231,6 +240,12 @@ app.get(
   asyncHandler(async (req, res) => {
     const { rows } = await pool.query("SELECT * FROM documents WHERE id = $1", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Document not found"));
+    await recordAuditEvent(pool, {
+      actor: actorFromRequest(req),
+      action: "document.accessed",
+      target: rows[0].id,
+      metadata: { uri: rows[0].uri },
+    });
     res.json(formatDocument(rows[0]));
   }),
 );
@@ -242,6 +257,17 @@ app.delete(
     const { rows } = await pool.query("DELETE FROM documents WHERE id = $1 RETURNING *", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Document not found"));
     res.json(formatDocument(rows[0]));
+  }),
+);
+
+// ── Audit endpoints ───────────────────────────────────────────────
+
+app.get(
+  "/audit-events",
+  asyncHandler(async (req, res) => {
+    const limit = Math.min(Number(req.query.limit) || 100, 500);
+    const { rows } = await pool.query("SELECT * FROM audit_events ORDER BY created_at DESC LIMIT $1", [limit]);
+    res.json(listResponse(rows.map(formatAuditEvent)));
   }),
 );
 
@@ -297,6 +323,15 @@ app.get(
       ));
     } else {
       ({ rows } = await pool.query("SELECT * FROM comments ORDER BY created_at ASC"));
+    }
+
+    if (resolvedDocId) {
+      await recordAuditEvent(pool, {
+        actor: actorFromRequest(req),
+        action: "document.accessed",
+        target: resolvedDocId,
+        metadata: { source: "comments.list" },
+      });
     }
 
     let data = rows.map(formatComment);
@@ -384,6 +419,12 @@ app.post(
     });
 
     const formatted = formatComment(comment);
+    await recordAuditEvent(pool, {
+      actor: actorFromRequest(req),
+      action: "comment.created",
+      target: formatted.id,
+      metadata: { document: formatted.document },
+    });
     triggerEvent(pool, "comment.created", { comment: formatted });
     res.status(201).json(formatted);
     broadcast(documentId, { type: "comment:created", comment: formatted });
@@ -396,6 +437,12 @@ app.get(
     const { rows } = await pool.query("SELECT * FROM comments WHERE id = $1", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
     let comment = formatComment(rows[0]);
+    await recordAuditEvent(pool, {
+      actor: actorFromRequest(req),
+      action: "document.accessed",
+      target: comment.document,
+      metadata: { comment: comment.id },
+    });
     const reactionsMap = await fetchReactionsForComments([comment.id]);
     comment = { ...comment, reactions: reactionsMap.get(comment.id) || [] };
     if (req.query.expand === "document") {
@@ -449,6 +496,12 @@ app.patch(
 
     const updated = await pool.query("SELECT * FROM comments WHERE id = $1", [req.params.id]);
     const formatted = formatComment(updated.rows[0]);
+    await recordAuditEvent(pool, {
+      actor: actorFromRequest(req),
+      action: body !== undefined || color !== undefined ? "comment.updated" : "comment.status_changed",
+      target: formatted.id,
+      metadata: { document: formatted.document, status: formatted.status },
+    });
     if (status === "closed") {
       triggerEvent(pool, "comment.resolved", { comment: formatted });
     }
@@ -464,6 +517,12 @@ app.delete(
     const { rows } = await pool.query("DELETE FROM comments WHERE id = $1 RETURNING *", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
     const formatted = formatComment(rows[0]);
+    await recordAuditEvent(pool, {
+      actor: actorFromRequest(req),
+      action: "comment.deleted",
+      target: formatted.id,
+      metadata: { document: formatted.document },
+    });
     triggerEvent(pool, "comment.deleted", { comment: formatted });
     res.json(formatted);
     broadcast(formatted.document, { type: "comment:deleted", comment: formatted });
@@ -651,6 +710,7 @@ async function start(options = {}) {
   const port = options.port !== undefined ? options.port : process.env.PORT || 3333;
   const host = options.host || "0.0.0.0";
   await initSchema();
+  await purgeAuditEvents(pool, process.env.REMARQ_AUDIT_RETENTION_DAYS || 90);
 
   const server = http.createServer(app);
   const wss = new WebSocketServer({ noServer: true });

--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,21 @@ const pool = new Pool({ connectionString: DATABASE_URL });
 // Wrap them so unhandled rejections become proper error responses.
 const asyncHandler = (fn) => (req, res, next) => fn(req, res, next).catch(next);
 
+async function withTransaction(fn) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 async function initSchema() {
   await pool.query(`
     CREATE TABLE IF NOT EXISTS documents (
@@ -255,7 +270,16 @@ app.get(
 app.delete(
   "/documents/:id",
   asyncHandler(async (req, res) => {
+    const deletedComments = await pool.query("SELECT * FROM comments WHERE document = $1", [req.params.id]);
     await pool.query("DELETE FROM comments WHERE document = $1", [req.params.id]);
+    for (const comment of deletedComments.rows) {
+      await recordAuditEvent(pool, {
+        actor: actorFromRequest(req),
+        action: "comment.deleted",
+        target: comment.id,
+        metadata: { document: comment.document, source: "document.delete" },
+      });
+    }
     const { rows } = await pool.query("DELETE FROM documents WHERE id = $1 RETURNING *", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Document not found"));
     res.json(formatDocument(rows[0]));
@@ -399,31 +423,33 @@ app.post(
     }
 
     const commentStatus = parent ? null : "open";
-    const comment = await insertWithId("cmt", async (id) => {
-      const { rows } = await pool.query(
-        "INSERT INTO comments (id, document, quote, prefix, suffix, body, author, status, parent, color) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING *",
-        [
-          id,
-          documentId,
-          quote || "",
-          prefix || null,
-          suffix || null,
-          cleanBody,
-          cleanAuthor,
-          commentStatus,
-          parent || null,
-          validatedColor,
-        ],
-      );
-      return rows[0];
-    });
-
-    const formatted = formatComment(comment);
-    await recordAuditEvent(pool, {
-      actor: actorFromRequest(req),
-      action: "comment.created",
-      target: formatted.id,
-      metadata: { document: formatted.document },
+    const formatted = await withTransaction(async (client) => {
+      const comment = await insertWithId("cmt", async (id) => {
+        const { rows } = await client.query(
+          "INSERT INTO comments (id, document, quote, prefix, suffix, body, author, status, parent, color) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING *",
+          [
+            id,
+            documentId,
+            quote || "",
+            prefix || null,
+            suffix || null,
+            cleanBody,
+            cleanAuthor,
+            commentStatus,
+            parent || null,
+            validatedColor,
+          ],
+        );
+        return rows[0];
+      });
+      const eventComment = formatComment(comment);
+      await recordAuditEvent(client, {
+        actor: actorFromRequest(req),
+        action: "comment.created",
+        target: eventComment.id,
+        metadata: { document: eventComment.document },
+      });
+      return eventComment;
     });
     triggerEvent(pool, "comment.created", { comment: formatted });
     res.status(201).json(formatted);
@@ -469,38 +495,41 @@ app.patch(
       return res.status(400).json(errorResponse('status must be "open" or "closed"'));
     }
 
-    if (color !== undefined) {
-      if (color === null) {
-        await pool.query("UPDATE comments SET color = NULL WHERE id = $1", [req.params.id]);
-      } else {
-        const validatedColor = validateColor(color);
-        if (!validatedColor) {
-          return res
-            .status(400)
-            .json(
-              errorResponse(
-                `color must be a valid hex code (e.g. #ff6b6b) or preset name (${PRESET_NAMES.join(", ")})`,
-              ),
-            );
-        }
-        await pool.query("UPDATE comments SET color = $1 WHERE id = $2", [validatedColor, req.params.id]);
+    let validatedColor;
+    if (color !== undefined && color !== null) {
+      validatedColor = validateColor(color);
+      if (!validatedColor) {
+        return res
+          .status(400)
+          .json(
+            errorResponse(`color must be a valid hex code (e.g. #ff6b6b) or preset name (${PRESET_NAMES.join(", ")})`),
+          );
       }
     }
 
-    if (body !== undefined) {
-      await pool.query("UPDATE comments SET body = $1 WHERE id = $2", [sanitize(body), req.params.id]);
-    }
-    if (status !== undefined) {
-      await pool.query("UPDATE comments SET status = $1 WHERE id = $2", [status, req.params.id]);
-    }
-
-    const updated = await pool.query("SELECT * FROM comments WHERE id = $1", [req.params.id]);
-    const formatted = formatComment(updated.rows[0]);
-    await recordAuditEvent(pool, {
-      actor: actorFromRequest(req),
-      action: "comment.updated",
-      target: formatted.id,
-      metadata: { document: formatted.document, status: formatted.status },
+    const formatted = await withTransaction(async (client) => {
+      if (color !== undefined) {
+        if (color === null) {
+          await client.query("UPDATE comments SET color = NULL WHERE id = $1", [req.params.id]);
+        } else {
+          await client.query("UPDATE comments SET color = $1 WHERE id = $2", [validatedColor, req.params.id]);
+        }
+      }
+      if (body !== undefined) {
+        await client.query("UPDATE comments SET body = $1 WHERE id = $2", [sanitize(body), req.params.id]);
+      }
+      if (status !== undefined) {
+        await client.query("UPDATE comments SET status = $1 WHERE id = $2", [status, req.params.id]);
+      }
+      const updated = await client.query("SELECT * FROM comments WHERE id = $1", [req.params.id]);
+      const eventComment = formatComment(updated.rows[0]);
+      await recordAuditEvent(client, {
+        actor: actorFromRequest(req),
+        action: "comment.updated",
+        target: eventComment.id,
+        metadata: { document: eventComment.document, status: eventComment.status },
+      });
+      return eventComment;
     });
     if (status === "closed") {
       triggerEvent(pool, "comment.resolved", { comment: formatted });
@@ -513,16 +542,28 @@ app.patch(
 app.delete(
   "/comments/:id",
   asyncHandler(async (req, res) => {
-    await pool.query("DELETE FROM comments WHERE parent = $1", [req.params.id]);
-    const { rows } = await pool.query("DELETE FROM comments WHERE id = $1 RETURNING *", [req.params.id]);
-    if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
-    const formatted = formatComment(rows[0]);
-    await recordAuditEvent(pool, {
-      actor: actorFromRequest(req),
-      action: "comment.deleted",
-      target: formatted.id,
-      metadata: { document: formatted.document },
+    const { formatted } = await withTransaction(async (client) => {
+      const deletedReplies = await client.query("DELETE FROM comments WHERE parent = $1 RETURNING *", [req.params.id]);
+      const { rows } = await client.query("DELETE FROM comments WHERE id = $1 RETURNING *", [req.params.id]);
+      if (rows.length === 0) return { formatted: null };
+      for (const reply of deletedReplies.rows) {
+        await recordAuditEvent(client, {
+          actor: actorFromRequest(req),
+          action: "comment.deleted",
+          target: reply.id,
+          metadata: { document: reply.document, parent: req.params.id },
+        });
+      }
+      const eventComment = formatComment(rows[0]);
+      await recordAuditEvent(client, {
+        actor: actorFromRequest(req),
+        action: "comment.deleted",
+        target: eventComment.id,
+        metadata: { document: eventComment.document },
+      });
+      return { formatted: eventComment };
     });
+    if (!formatted) return res.status(404).json(errorResponse("Comment not found"));
     triggerEvent(pool, "comment.deleted", { comment: formatted });
     res.json(formatted);
     broadcast(formatted.document, { type: "comment:deleted", comment: formatted });

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "index.js",
+    "audit-log.js",
     "generate-id.js",
     "normalize-uri.js",
     "sanitize.js",

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -1285,6 +1285,63 @@ describe("API", async () => {
     });
   });
 
+  // ── Audit logging ──────────────────────────────────────────────
+
+  describe("audit logging", () => {
+    async function latestAudit(action) {
+      const { rows } = await pool.query(
+        "SELECT * FROM audit_events WHERE action = $1 ORDER BY created_at DESC LIMIT 1",
+        [action],
+      );
+      return rows[0];
+    }
+
+    it("records comment create, update, delete, and document access events", async () => {
+      const create = await fetch(`${BASE}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Remarq-User": "alice@example.com" },
+        body: JSON.stringify({ uri: "https://example.com/audit", quote: "q", body: "b", author: "alice" }),
+      });
+      const comment = await create.json();
+
+      const created = await latestAudit("comment.created");
+      assert.equal(created.actor, "alice@example.com");
+      assert.equal(created.target, comment.id);
+      assert.ok(created.created_at);
+
+      await fetch(`${BASE}/comments/${comment.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", "X-Remarq-User": "alice@example.com" },
+        body: JSON.stringify({ body: "updated", status: "closed" }),
+      });
+      const updated = await latestAudit("comment.updated");
+      assert.equal(updated.target, comment.id);
+      assert.equal(updated.metadata.status, "closed");
+
+      await fetch(`${BASE}/comments/${comment.id}`, { headers: { "X-Remarq-User": "bob@example.com" } });
+      const accessed = await latestAudit("document.accessed");
+      assert.equal(accessed.actor, "bob@example.com");
+      assert.equal(accessed.target, comment.document);
+
+      await fetch(`${BASE}/comments/${comment.id}`, {
+        method: "DELETE",
+        headers: { "X-Remarq-User": "alice@example.com" },
+      });
+      const deleted = await latestAudit("comment.deleted");
+      assert.equal(deleted.target, comment.id);
+    });
+
+    it("purges audit events older than the 90-day minimum", async () => {
+      await pool.query(
+        "INSERT INTO audit_events (actor, action, target, created_at) VALUES ('a', 'comment.created', 'old', NOW() - INTERVAL '91 days')",
+      );
+      const { purgeAuditEvents } = await import("./audit-log.js");
+      await purgeAuditEvents(pool, 1);
+      const { rows } = await pool.query("SELECT * FROM audit_events WHERE target = 'old'");
+      assert.equal(rows.length, 0);
+    });
+  });
+
   // ── Reactions ────────────────────────────────────────────────────
 
   describe("POST /comments/:id/reactions", () => {

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -134,34 +134,11 @@ describe("validate-color", async () => {
 });
 
 describe("audit-log", async () => {
-  const { actorFromRequest, formatAuditEvent } = await import("./audit-log.js");
+  const { actorFromRequest } = await import("./audit-log.js");
 
   it("uses trusted identity headers before body author", () => {
     const req = { get: (name) => (name === "X-Remarq-User" ? "alice" : null), body: { author: "bob" } };
     assert.equal(actorFromRequest(req), "alice");
-  });
-
-  it("formats audit events", () => {
-    const created = new Date("2026-04-27T00:00:00Z");
-    assert.deepEqual(
-      formatAuditEvent({
-        id: 1,
-        actor: "alice",
-        action: "comment.created",
-        target: "cmt_1",
-        metadata: {},
-        created_at: created,
-      }),
-      {
-        id: "1",
-        object: "audit_event",
-        actor: "alice",
-        action: "comment.created",
-        target: "cmt_1",
-        metadata: {},
-        created_at: "2026-04-27T00:00:00.000Z",
-      },
-    );
   });
 });
 
@@ -1329,6 +1306,26 @@ describe("API", async () => {
       });
       const deleted = await latestAudit("comment.deleted");
       assert.equal(deleted.target, comment.id);
+    });
+
+    it("records comment delete events when deleting a document", async () => {
+      const c = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Remarq-User": "alice@example.com" },
+          body: JSON.stringify({ uri: "https://example.com/audit-doc-delete", quote: "q", body: "b", author: "alice" }),
+        })
+      ).json();
+      await fetch(`${BASE}/documents/${c.document}`, {
+        method: "DELETE",
+        headers: { "X-Remarq-User": "admin@example.com" },
+      });
+      const { rows } = await pool.query("SELECT * FROM audit_events WHERE action = 'comment.deleted' AND target = $1", [
+        c.id,
+      ]);
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].actor, "admin@example.com");
+      assert.ok(rows[0].created_at);
     });
 
     it("purges audit events older than the 90-day minimum", async () => {

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -133,6 +133,38 @@ describe("validate-color", async () => {
   });
 });
 
+describe("audit-log", async () => {
+  const { actorFromRequest, formatAuditEvent } = await import("./audit-log.js");
+
+  it("uses trusted identity headers before body author", () => {
+    const req = { get: (name) => (name === "X-Remarq-User" ? "alice" : null), body: { author: "bob" } };
+    assert.equal(actorFromRequest(req), "alice");
+  });
+
+  it("formats audit events", () => {
+    const created = new Date("2026-04-27T00:00:00Z");
+    assert.deepEqual(
+      formatAuditEvent({
+        id: 1,
+        actor: "alice",
+        action: "comment.created",
+        target: "cmt_1",
+        metadata: {},
+        created_at: created,
+      }),
+      {
+        id: "1",
+        object: "audit_event",
+        actor: "alice",
+        action: "comment.created",
+        target: "cmt_1",
+        metadata: {},
+        created_at: "2026-04-27T00:00:00.000Z",
+      },
+    );
+  });
+});
+
 describe("webhooks", async () => {
   const { signPayload, deliverWebhook, retryWithBackoff } = await import("./webhooks.js");
 
@@ -264,6 +296,7 @@ describe("API", async () => {
     await pool.query("DELETE FROM comments");
     await pool.query("DELETE FROM documents");
     await pool.query("DELETE FROM webhooks");
+    await pool.query("DELETE FROM audit_events");
   });
 
   // ── Health check ─────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Added durable database audit records for comment create/update/delete and document access. Audit rows include actor, action, target, metadata, and timestamp, with 90-day minimum retention.

## Why

Closes #279. Block Security requires auditable records for sensitive activity without relying on ephemeral logs or webhook delivery.

## New/Changed Endpoints

No endpoints changed.

## How to verify

- `npm run check`
- Create/access/update/delete a comment and verify rows in `audit_events`:
  `psql "$DATABASE_URL" -c "select actor, action, target, created_at from audit_events order by created_at desc limit 10;"`

## Manual testing checklist

- [ ] Server starts without errors (`npm run start`)
- [x] Existing tests pass (`npm test`)
- [ ] Tested in browser (annotations, sidebar, highlights work)
- [ ] Tested API changes with curl (include example commands above)
- [ ] No console errors in browser DevTools
