### PR TITLE
Add configurable comment retention and soft delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Security
 
+- Added configurable comment retention with soft-delete recovery and scheduled purge.
 - CORS now restricted to trusted origins via `ALLOWED_ORIGINS` env var (previously allowed all origins)
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Changed
 
+- Replies are intentionally one level deep; `POST /comments` now requires `parent` to reference a top-level/root comment and returns `404` for missing, deleted, or non-root parents.
 - Landing page rewritten with agent-first positioning: new 3-step workflow (Comment → Agent Revises → Resolved), tabbed Quick Start, and removal of external CSS dependency
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -157,17 +157,17 @@ Stripe-inspired resource pattern. All responses include an `object` field. **Ful
 
 ### Comments
 
-| Method   | Endpoint                    | Description                                                     |
-| -------- | --------------------------- | --------------------------------------------------------------- |
-| `GET`    | `/comments`                 | List all comments                                               |
-| `GET`    | `/comments?document=<id>`   | List comments by document ID                                    |
-| `GET`    | `/comments?uri=<url>`       | List comments by document URI                                   |
-| `GET`    | `/comments?status=open`     | **The money endpoint.** Get all unresolved feedback.            |
-| `GET`    | `/comments?expand=document` | Hydrate document objects inline                                 |
-| `POST`   | `/comments`                 | Create a comment (set `parent` to reply to an existing comment) |
-| `GET`    | `/comments/:id`             | Retrieve a comment                                              |
-| `PATCH`  | `/comments/:id`             | Update body, status, or color                                   |
-| `DELETE` | `/comments/:id`             | Soft-delete a comment and its replies                           |
+| Method   | Endpoint                    | Description                                                          |
+| -------- | --------------------------- | -------------------------------------------------------------------- |
+| `GET`    | `/comments`                 | List all comments                                                    |
+| `GET`    | `/comments?document=<id>`   | List comments by document ID                                         |
+| `GET`    | `/comments?uri=<url>`       | List comments by document URI                                        |
+| `GET`    | `/comments?status=open`     | **The money endpoint.** Get all unresolved feedback.                 |
+| `GET`    | `/comments?expand=document` | Hydrate document objects inline                                      |
+| `POST`   | `/comments`                 | Create a comment (set `parent` to reply to a top-level/root comment) |
+| `GET`    | `/comments/:id`             | Retrieve a comment                                                   |
+| `PATCH`  | `/comments/:id`             | Update body, status, or color                                        |
+| `DELETE` | `/comments/:id`             | Soft-delete a comment and its one-level replies                      |
 
 ### Webhooks
 
@@ -198,7 +198,7 @@ Status is a thread-level concept — only root comments have status (`"open"` or
 }
 ```
 
-For replies, set `parent` to the parent comment's ID. Replies don't need `quote`/`prefix`/`suffix`.
+For replies, set `parent` to a top-level/root comment ID. Replies are one level deep and do not need `quote`/`prefix`/`suffix`.
 
 ### Highlight Colors
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
+## Enterprise security
+
+Configurable comment retention and soft delete controls are documented in [docs/data-retention.md](docs/data-retention.md).
+
 ## OpenAPI Spec
 
 The server exposes a machine-readable OpenAPI 3.0 spec at:

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
-## Enterprise security
+## Data retention
 
-Configurable comment retention and soft delete controls are documented in [docs/data-retention.md](docs/data-retention.md).
+Configurable comment retention and soft-delete controls are documented in [docs/data-retention.md](docs/data-retention.md).
 
 ## OpenAPI Spec
 
@@ -167,7 +167,7 @@ Stripe-inspired resource pattern. All responses include an `object` field. **Ful
 | `POST`   | `/comments`                 | Create a comment (set `parent` to reply to an existing comment) |
 | `GET`    | `/comments/:id`             | Retrieve a comment                                              |
 | `PATCH`  | `/comments/:id`             | Update body, status, or color                                   |
-| `DELETE` | `/comments/:id`             | Delete a comment and its replies                                |
+| `DELETE` | `/comments/:id`             | Soft-delete a comment and its replies                           |
 
 ### Webhooks
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -630,7 +630,7 @@ curl -X PATCH http://localhost:3000/comments/cmt_abc123 \
 
 #### `DELETE /comments/:id`
 
-Delete a comment and all its replies.
+Soft-delete a comment and all its replies. Soft-deleted comments are excluded from read/list endpoints and remain recoverable in the database until `purge_after`.
 
 **Parameters:**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,7 +346,7 @@ curl "http://localhost:3000/comments?document=doc_k3mXp9q2aBvN&expand=document"
 
 #### `POST /comments`
 
-Create a new comment or reply.
+Create a new comment or reply. Replies are intentionally one level deep: `parent` must reference a top-level/root comment. Missing, deleted, or non-root parent comments return `404 Not Found`.
 
 **Request Body (top-level comment):**
 
@@ -378,7 +378,7 @@ Create a new comment or reply.
 - `author` (string) — Author name
 - `uri` OR `document` (string) — Document URI or ID
 - `quote` (string) — Required for top-level comments; not required for replies
-- `parent` (string, optional) — Parent comment ID (for replies)
+- `parent` (string, optional) — Top-level/root parent comment ID for one-level replies. Missing, deleted, or non-root parent comments return `404 Not Found`.
 
 **Optional Fields:**
 
@@ -407,7 +407,7 @@ Create a new comment or reply.
 
 - `201 Created` — Comment created
 - `400 Bad Request` — Missing required fields or invalid data
-- `404 Not Found` — Referenced document ID does not exist
+- `404 Not Found` — Referenced document ID does not exist, or the requested reply parent is missing, deleted, or not a top-level/root comment
 
 **Error Responses:**
 
@@ -630,7 +630,7 @@ curl -X PATCH http://localhost:3000/comments/cmt_abc123 \
 
 #### `DELETE /comments/:id`
 
-Soft-delete a comment and all its replies. Soft-deleted comments are excluded from read/list endpoints and remain recoverable in the database until `purge_after`.
+Soft-delete a comment and its one-level replies. Replies are one level deep; deleting a top-level comment also soft-deletes its direct replies. Soft-deleted comments are excluded from read/list endpoints and remain recoverable in the database until `purge_after`.
 
 **Parameters:**
 
@@ -667,7 +667,7 @@ curl -X DELETE http://localhost:3000/comments/cmt_abc123
 
 **Notes:**
 
-- Deleting a comment cascades to all replies on that comment
+- Deleting a top-level comment cascades to its one-level replies
 
 ---
 

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -50,11 +50,13 @@ The `.env` file is read automatically by Docker Compose. Use a strong, random pa
 
 ### Environment variables
 
-| Variable            | Default                                    | Description                                 |
-| ------------------- | ------------------------------------------ | ------------------------------------------- |
-| `DATABASE_URL`      | `postgresql://postgres@localhost/postgres` | PostgreSQL connection string                |
-| `PORT`              | `3333`                                     | Port the server listens on                  |
-| `POSTGRES_PASSWORD` | _(required in Docker)_                     | Password for the bundled Postgres container |
+| Variable                        | Default                                    | Description                                                |
+| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `DATABASE_URL`                  | `postgresql://postgres@localhost/postgres` | PostgreSQL connection string                               |
+| `PORT`                          | `3333`                                     | Port the server listens on                                 |
+| `POSTGRES_PASSWORD`             | _(required in Docker)_                     | Password for the bundled Postgres container                |
+| `REMARQ_COMMENT_RETENTION_DAYS` | `365`                                      | Days before active comments are soft-deleted               |
+| `REMARQ_COMMENT_RECOVERY_DAYS`  | `30`                                       | Days soft-deleted comments remain recoverable before purge |
 
 ### Reverse proxy (HTTPS)
 

--- a/docs/data-retention.md
+++ b/docs/data-retention.md
@@ -1,6 +1,6 @@
 # Comment retention and deletion
 
-Remarq supports a two-stage deletion lifecycle:
+Remarq supports a deletion lifecycle:
 
 1. **Active retention** — comments older than `REMARQ_COMMENT_RETENTION_DAYS` are soft-deleted automatically.
 2. **Recovery window** — soft-deleted comments stay in the database until `purge_after`.
@@ -13,7 +13,7 @@ REMARQ_COMMENT_RETENTION_DAYS=365
 REMARQ_COMMENT_RECOVERY_DAYS=30
 ```
 
-Defaults are 365 days active retention and 30 days recovery. The lifecycle runs at server start. Operators can restart the service from scheduled maintenance to enforce the policy daily.
+Defaults are 365 days active retention and 30 days recovery. The lifecycle runs at server start and then once every 24 hours while the service is running.
 
 ## API behavior
 
@@ -24,5 +24,3 @@ Defaults are 365 days active retention and 30 days recovery. The lifecycle runs 
 ```sql
 SELECT id, deleted_at, purge_after FROM comments WHERE id = 'cmt_...';
 ```
-
-Closes #280.

--- a/docs/data-retention.md
+++ b/docs/data-retention.md
@@ -1,0 +1,28 @@
+# Comment retention and deletion
+
+Remarq supports a two-stage deletion lifecycle:
+
+1. **Active retention** — comments older than `REMARQ_COMMENT_RETENTION_DAYS` are soft-deleted automatically.
+2. **Recovery window** — soft-deleted comments stay in the database until `purge_after`.
+3. **Permanent purge** — comments whose `purge_after` has passed are removed.
+
+## Configuration
+
+```bash
+REMARQ_COMMENT_RETENTION_DAYS=365
+REMARQ_COMMENT_RECOVERY_DAYS=30
+```
+
+Defaults are 365 days active retention and 30 days recovery. The lifecycle runs at server start. Operators can restart the service from scheduled maintenance to enforce the policy daily.
+
+## API behavior
+
+`DELETE /comments/:id` soft-deletes the target comment and replies. Deleted comments are excluded from comment list/read endpoints and remain recoverable from the database until `purge_after`.
+
+## Verification
+
+```sql
+SELECT id, deleted_at, purge_after FROM comments WHERE id = 'cmt_...';
+```
+
+Closes #280.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -234,7 +234,7 @@ Query params can be combined (e.g., `?document=<id>&status=open&expand=document`
 
 ### POST /comments
 
-Create a new comment or reply.
+Create a new comment or reply. Replies are intentionally one level deep: `parent` must reference a top-level/root comment. Missing, deleted, or non-root parent comments return `404 Not Found`.
 
 **Request Body (top-level comment):**
 ```json
@@ -267,7 +267,7 @@ Create a new comment or reply.
 **Optional fields:**
 - `prefix` — Text context before the quote
 - `suffix` — Text context after the quote
-- `parent` — Parent comment ID (makes this a reply)
+- `parent` — Top-level/root parent comment ID for a one-level reply; missing, deleted, or non-root parents return `404`
 
 **Response (201 Created):**
 ```json
@@ -292,7 +292,7 @@ Create a new comment or reply.
 - Replies have `status: null` and cannot be resolved independently.
 - HTML tags in `body` and `author` are stripped for safety.
 
-**Errors:** `400` for missing required fields, `404` if referenced document ID doesn't exist.
+**Errors:** `400` for missing required fields, `404` if referenced document ID doesn't exist or a reply parent is missing, deleted, or not top-level/root.
 
 ---
 
@@ -361,11 +361,11 @@ Both fields are optional. `status` accepts `"open"` or `"closed"` and can only b
 
 ### DELETE /comments/:id
 
-Soft-delete a comment and all its replies. Soft-deleted comments are excluded from read/list endpoints and remain recoverable in the database until `purge_after`.
+Soft-delete a comment and its one-level replies. Replies are intentionally one level deep; deleting a top-level/root comment also soft-deletes its direct replies. Soft-deleted comments are excluded from read/list endpoints and remain recoverable in the database until `purge_after`.
 
 **Response (200):** Returns the deleted comment object. Returns `404` if not found.
 
-Deleting a comment cascades to all replies.
+Deleting a top-level comment cascades to its one-level replies.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -361,7 +361,7 @@ Both fields are optional. `status` accepts `"open"` or `"closed"` and can only b
 
 ### DELETE /comments/:id
 
-Delete a comment and all its replies.
+Soft-delete a comment and all its replies. Soft-deleted comments are excluded from read/list endpoints and remain recoverable in the database until `purge_after`.
 
 **Response (200):** Returns the deleted comment object. Returns `404` if not found.
 

--- a/server/index.js
+++ b/server/index.js
@@ -371,7 +371,10 @@ app.post(
     }
 
     if (parent) {
-      const parentResult = await pool.query("SELECT id FROM comments WHERE id = $1 AND deleted_at IS NULL", [parent]);
+      const parentResult = await pool.query(
+        "SELECT id FROM comments WHERE id = $1 AND deleted_at IS NULL AND parent IS NULL",
+        [parent],
+      );
       if (parentResult.rows.length === 0) return res.status(404).json(errorResponse("Parent comment not found"));
     }
 

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,7 @@ const { triggerEvent } = require("./webhooks.js");
 const { registerWebhookRoutes } = require("./webhook-routes.js");
 const path = require("path");
 const openApiSpec = require("./openapi.js");
-const { ensureRetentionColumns, retentionConfig, runRetention, softDeleteComment } = require("./retention.js");
+const { ensureRetentionColumns, retentionConfig, runRetention, softDeleteCommentThread } = require("./retention.js");
 
 const app = express();
 const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : ["http://localhost:3333"];
@@ -482,11 +482,7 @@ app.delete(
   "/comments/:id",
   asyncHandler(async (req, res) => {
     const { recoveryDays } = retentionConfig();
-    await pool.query(
-      "UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval WHERE parent = $1 AND deleted_at IS NULL",
-      [req.params.id, recoveryDays],
-    );
-    const comment = await softDeleteComment(pool, req.params.id, recoveryDays);
+    const comment = await softDeleteCommentThread(pool, req.params.id, recoveryDays);
     if (!comment) return res.status(404).json(errorResponse("Comment not found"));
     const formatted = formatComment(comment);
     triggerEvent(pool, "comment.deleted", { comment: formatted });

--- a/server/index.js
+++ b/server/index.js
@@ -15,6 +15,7 @@ const { triggerEvent } = require("./webhooks.js");
 const { registerWebhookRoutes } = require("./webhook-routes.js");
 const path = require("path");
 const openApiSpec = require("./openapi.js");
+const { ensureRetentionColumns, retentionConfig, runRetention, softDeleteComment } = require("./retention.js");
 
 const app = express();
 const allowedOrigins = process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(",") : ["http://localhost:3333"];
@@ -68,6 +69,8 @@ async function initSchema() {
       PRIMARY KEY (comment_id, author, emoji)
     )
   `);
+
+  await ensureRetentionColumns(pool);
 
   // Allow NULL status for replies (idempotent)
   await pool.query(`ALTER TABLE comments ALTER COLUMN status DROP NOT NULL`);
@@ -277,26 +280,28 @@ app.get(
       if (status) {
         ({ rows } = await pool.query(
           `SELECT * FROM comments WHERE document = $1
+          AND deleted_at IS NULL
           AND ((parent IS NULL AND status = $2)
             OR (parent IN (SELECT id FROM comments WHERE document = $1 AND parent IS NULL AND status = $2)))
           ORDER BY created_at ASC`,
           [resolvedDocId, status],
         ));
       } else {
-        ({ rows } = await pool.query("SELECT * FROM comments WHERE document = $1 ORDER BY created_at ASC", [
-          resolvedDocId,
-        ]));
+        ({ rows } = await pool.query(
+          "SELECT * FROM comments WHERE document = $1 AND deleted_at IS NULL ORDER BY created_at ASC",
+          [resolvedDocId],
+        ));
       }
     } else if (status) {
       ({ rows } = await pool.query(
         `SELECT * FROM comments
-        WHERE (parent IS NULL AND status = $1)
+        WHERE deleted_at IS NULL AND (parent IS NULL AND status = $1)
           OR (parent IN (SELECT id FROM comments WHERE parent IS NULL AND status = $1))
         ORDER BY created_at ASC`,
         [status],
       ));
     } else {
-      ({ rows } = await pool.query("SELECT * FROM comments ORDER BY created_at ASC"));
+      ({ rows } = await pool.query("SELECT * FROM comments WHERE deleted_at IS NULL ORDER BY created_at ASC"));
     }
 
     let data = rows.map(formatComment);
@@ -393,7 +398,7 @@ app.post(
 app.get(
   "/comments/:id",
   asyncHandler(async (req, res) => {
-    const { rows } = await pool.query("SELECT * FROM comments WHERE id = $1", [req.params.id]);
+    const { rows } = await pool.query("SELECT * FROM comments WHERE id = $1 AND deleted_at IS NULL", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
     let comment = formatComment(rows[0]);
     const reactionsMap = await fetchReactionsForComments([comment.id]);
@@ -409,7 +414,7 @@ app.get(
 app.patch(
   "/comments/:id",
   asyncHandler(async (req, res) => {
-    const { rows } = await pool.query("SELECT * FROM comments WHERE id = $1", [req.params.id]);
+    const { rows } = await pool.query("SELECT * FROM comments WHERE id = $1 AND deleted_at IS NULL", [req.params.id]);
     if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
 
     const { body, status, color } = req.body;
@@ -460,10 +465,14 @@ app.patch(
 app.delete(
   "/comments/:id",
   asyncHandler(async (req, res) => {
-    await pool.query("DELETE FROM comments WHERE parent = $1", [req.params.id]);
-    const { rows } = await pool.query("DELETE FROM comments WHERE id = $1 RETURNING *", [req.params.id]);
-    if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
-    const formatted = formatComment(rows[0]);
+    const { recoveryDays } = retentionConfig();
+    await pool.query(
+      "UPDATE comments SET deleted_at = COALESCE(deleted_at, NOW()), purge_after = COALESCE(purge_after, NOW() + ($2::text || ' days')::interval) WHERE parent = $1",
+      [req.params.id, recoveryDays],
+    );
+    const comment = await softDeleteComment(pool, req.params.id, recoveryDays);
+    if (!comment) return res.status(404).json(errorResponse("Comment not found"));
+    const formatted = formatComment(comment);
     triggerEvent(pool, "comment.deleted", { comment: formatted });
     res.json(formatted);
     broadcast(formatted.document, { type: "comment:deleted", comment: formatted });
@@ -651,6 +660,7 @@ async function start(options = {}) {
   const port = options.port !== undefined ? options.port : process.env.PORT || 3333;
   const host = options.host || "0.0.0.0";
   await initSchema();
+  await runRetention(pool, retentionConfig());
 
   const server = http.createServer(app);
   const wss = new WebSocketServer({ noServer: true });

--- a/server/index.js
+++ b/server/index.js
@@ -282,7 +282,7 @@ app.get(
           `SELECT * FROM comments WHERE document = $1
           AND deleted_at IS NULL
           AND ((parent IS NULL AND status = $2)
-            OR (parent IN (SELECT id FROM comments WHERE document = $1 AND parent IS NULL AND status = $2)))
+            OR (parent IN (SELECT id FROM comments WHERE document = $1 AND parent IS NULL AND status = $2 AND deleted_at IS NULL)))
           ORDER BY created_at ASC`,
           [resolvedDocId, status],
         ));
@@ -295,8 +295,8 @@ app.get(
     } else if (status) {
       ({ rows } = await pool.query(
         `SELECT * FROM comments
-        WHERE deleted_at IS NULL AND (parent IS NULL AND status = $1)
-          OR (parent IN (SELECT id FROM comments WHERE parent IS NULL AND status = $1))
+        WHERE deleted_at IS NULL AND ((parent IS NULL AND status = $1)
+          OR (parent IN (SELECT id FROM comments WHERE parent IS NULL AND status = $1 AND deleted_at IS NULL)))
         ORDER BY created_at ASC`,
         [status],
       ));
@@ -366,6 +366,11 @@ app.post(
       }
     } catch (err) {
       return res.status(400).json(errorResponse(err.message));
+    }
+
+    if (parent) {
+      const parentResult = await pool.query("SELECT id FROM comments WHERE id = $1 AND deleted_at IS NULL", [parent]);
+      if (parentResult.rows.length === 0) return res.status(404).json(errorResponse("Parent comment not found"));
     }
 
     const commentStatus = parent ? null : "open";
@@ -467,7 +472,7 @@ app.delete(
   asyncHandler(async (req, res) => {
     const { recoveryDays } = retentionConfig();
     await pool.query(
-      "UPDATE comments SET deleted_at = COALESCE(deleted_at, NOW()), purge_after = COALESCE(purge_after, NOW() + ($2::text || ' days')::interval) WHERE parent = $1",
+      "UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval WHERE parent = $1 AND deleted_at IS NULL",
       [req.params.id, recoveryDays],
     );
     const comment = await softDeleteComment(pool, req.params.id, recoveryDays);
@@ -498,7 +503,9 @@ app.post(
     const cleanAuthor = sanitize(author);
 
     // Verify comment exists
-    const { rows: check } = await pool.query("SELECT id FROM comments WHERE id = $1", [req.params.id]);
+    const { rows: check } = await pool.query("SELECT id FROM comments WHERE id = $1 AND deleted_at IS NULL", [
+      req.params.id,
+    ]);
     if (check.length === 0) return res.status(404).json(errorResponse("Comment not found"));
 
     await pool.query(
@@ -527,7 +534,9 @@ app.delete(
     const cleanAuthor = sanitize(author);
 
     // Verify comment exists
-    const { rows: check } = await pool.query("SELECT id FROM comments WHERE id = $1", [req.params.id]);
+    const { rows: check } = await pool.query("SELECT id FROM comments WHERE id = $1 AND deleted_at IS NULL", [
+      req.params.id,
+    ]);
     if (check.length === 0) return res.status(404).json(errorResponse("Comment not found"));
 
     await pool.query("DELETE FROM reactions WHERE comment_id = $1 AND author = $2 AND emoji = $3", [
@@ -579,6 +588,7 @@ function broadcast(documentId, event) {
 }
 
 const SUBSCRIBE_TIMEOUT_MS = 30000; // Close connections that never subscribe
+const RETENTION_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 function handleWsConnection(ws) {
   const subscribedDocs = new Set();
@@ -662,6 +672,11 @@ async function start(options = {}) {
   await initSchema();
   await runRetention(pool, retentionConfig());
 
+  const retentionTimer = setInterval(() => {
+    runRetention(pool, retentionConfig()).catch((err) => console.error("[retention] Failed to run:", err));
+  }, RETENTION_INTERVAL_MS);
+  retentionTimer.unref();
+
   const server = http.createServer(app);
   const wss = new WebSocketServer({ noServer: true });
 
@@ -678,6 +693,7 @@ async function start(options = {}) {
 
   // Graceful shutdown: terminate all WebSocket clients before stopping
   server.on("close", () => {
+    clearInterval(retentionTimer);
     for (const ws of wss.clients) {
       ws.terminate();
     }

--- a/server/index.js
+++ b/server/index.js
@@ -288,7 +288,7 @@ app.get(
         ));
       } else {
         ({ rows } = await pool.query(
-          "SELECT * FROM comments WHERE document = $1 AND deleted_at IS NULL ORDER BY created_at ASC",
+          "SELECT * FROM comments WHERE document = $1 AND deleted_at IS NULL AND (parent IS NULL OR parent IN (SELECT id FROM comments WHERE deleted_at IS NULL)) ORDER BY created_at ASC",
           [resolvedDocId],
         ));
       }
@@ -301,7 +301,9 @@ app.get(
         [status],
       ));
     } else {
-      ({ rows } = await pool.query("SELECT * FROM comments WHERE deleted_at IS NULL ORDER BY created_at ASC"));
+      ({ rows } = await pool.query(
+        "SELECT * FROM comments WHERE deleted_at IS NULL AND (parent IS NULL OR parent IN (SELECT id FROM comments WHERE deleted_at IS NULL)) ORDER BY created_at ASC",
+      ));
     }
 
     let data = rows.map(formatComment);
@@ -403,7 +405,10 @@ app.post(
 app.get(
   "/comments/:id",
   asyncHandler(async (req, res) => {
-    const { rows } = await pool.query("SELECT * FROM comments WHERE id = $1 AND deleted_at IS NULL", [req.params.id]);
+    const { rows } = await pool.query(
+      "SELECT * FROM comments WHERE id = $1 AND deleted_at IS NULL AND (parent IS NULL OR parent IN (SELECT id FROM comments WHERE deleted_at IS NULL))",
+      [req.params.id],
+    );
     if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
     let comment = formatComment(rows[0]);
     const reactionsMap = await fetchReactionsForComments([comment.id]);
@@ -419,7 +424,10 @@ app.get(
 app.patch(
   "/comments/:id",
   asyncHandler(async (req, res) => {
-    const { rows } = await pool.query("SELECT * FROM comments WHERE id = $1 AND deleted_at IS NULL", [req.params.id]);
+    const { rows } = await pool.query(
+      "SELECT * FROM comments WHERE id = $1 AND deleted_at IS NULL AND (parent IS NULL OR parent IN (SELECT id FROM comments WHERE deleted_at IS NULL))",
+      [req.params.id],
+    );
     if (rows.length === 0) return res.status(404).json(errorResponse("Comment not found"));
 
     const { body, status, color } = req.body;

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -415,12 +415,12 @@ const spec = {
 
       delete: {
         operationId: "deleteComment",
-        summary: "Delete a comment and its replies",
+        summary: "Soft-delete a comment and its replies",
         tags: ["comments"],
         "x-cli": {
           group: "comments",
           command: "delete <id>",
-          describe: "Delete a comment",
+          describe: "Soft-delete a comment",
           positional: [{ name: "id", describe: "Comment ID", from: "path", paramName: "id" }],
         },
         parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -298,11 +298,11 @@ const spec = {
           {
             group: "comments",
             command: "reply <parent-id>",
-            describe: "Reply to a comment",
+            describe: "Reply to a top-level/root comment",
             positional: [
               {
                 name: "parent-id",
-                describe: "Parent comment ID",
+                describe: "Top-level/root parent comment ID",
                 from: "body",
                 field: "parent",
               },
@@ -325,7 +325,7 @@ const spec = {
               suffix: { type: "string" },
               body: { type: "string" },
               author: { type: "string" },
-              parent: { type: "string", description: "Parent comment ID (for replies)" },
+              parent: { type: "string", description: "Top-level/root parent comment ID (for one-level replies)" },
               color: { type: "string", description: "Preset name or #rrggbb hex" },
             },
           }),
@@ -333,7 +333,7 @@ const spec = {
         responses: {
           201: { description: "Comment created", content: jsonContent(commentSchema) },
           400: { description: "Bad request", content: jsonContent(errorSchema) },
-          404: { description: "Document not found", content: jsonContent(errorSchema) },
+          404: { description: "Document or top-level parent comment not found", content: jsonContent(errorSchema) },
         },
       },
     },
@@ -415,7 +415,7 @@ const spec = {
 
       delete: {
         operationId: "deleteComment",
-        summary: "Soft-delete a comment and its replies",
+        summary: "Soft-delete a comment and its one-level replies",
         description:
           "Marks a comment thread as deleted. Soft-deleted comments are hidden from read/list/mutation paths and remain recoverable in the database until the configured purge window expires.",
         tags: ["comments"],

--- a/server/openapi.js
+++ b/server/openapi.js
@@ -416,6 +416,8 @@ const spec = {
       delete: {
         operationId: "deleteComment",
         summary: "Soft-delete a comment and its replies",
+        description:
+          "Marks a comment thread as deleted. Soft-deleted comments are hidden from read/list/mutation paths and remain recoverable in the database until the configured purge window expires.",
         tags: ["comments"],
         "x-cli": {
           group: "comments",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "index.js",
+    "retention.js",
     "generate-id.js",
     "normalize-uri.js",
     "sanitize.js",

--- a/server/retention.js
+++ b/server/retention.js
@@ -1,0 +1,30 @@
+function retentionConfig(env = process.env) {
+  const retentionDays = Math.max(Number(env.REMARQ_COMMENT_RETENTION_DAYS) || 365, 1);
+  const recoveryDays = Math.max(Number(env.REMARQ_COMMENT_RECOVERY_DAYS) || 30, 1);
+  return { retentionDays, recoveryDays };
+}
+
+async function ensureRetentionColumns(pool) {
+  await pool.query("ALTER TABLE comments ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ");
+  await pool.query("ALTER TABLE comments ADD COLUMN IF NOT EXISTS purge_after TIMESTAMPTZ");
+  await pool.query("CREATE INDEX IF NOT EXISTS comments_deleted_at_idx ON comments (deleted_at)");
+  await pool.query("CREATE INDEX IF NOT EXISTS comments_purge_after_idx ON comments (purge_after)");
+}
+
+async function softDeleteComment(pool, id, recoveryDays) {
+  const { rows } = await pool.query(
+    "UPDATE comments SET deleted_at = COALESCE(deleted_at, NOW()), purge_after = COALESCE(purge_after, NOW() + ($2::text || ' days')::interval) WHERE id = $1 RETURNING *",
+    [id, recoveryDays],
+  );
+  return rows[0] || null;
+}
+
+async function runRetention(pool, { retentionDays, recoveryDays } = retentionConfig()) {
+  await pool.query(
+    "UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval WHERE deleted_at IS NULL AND created_at < NOW() - ($1::text || ' days')::interval",
+    [retentionDays, recoveryDays],
+  );
+  await pool.query("DELETE FROM comments WHERE deleted_at IS NOT NULL AND purge_after <= NOW()");
+}
+
+module.exports = { ensureRetentionColumns, retentionConfig, runRetention, softDeleteComment };

--- a/server/retention.js
+++ b/server/retention.js
@@ -19,16 +19,32 @@ async function softDeleteComment(pool, id, recoveryDays) {
   return rows[0] || null;
 }
 
+async function softDeleteRepliesOfDeletedParents(pool, recoveryDays) {
+  while (true) {
+    const result = await pool.query(
+      `UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($1::text || ' days')::interval
+       WHERE deleted_at IS NULL
+       AND parent IN (SELECT id FROM comments WHERE deleted_at IS NOT NULL)`,
+      [recoveryDays],
+    );
+    if (result.rowCount === 0) break;
+  }
+}
+
 async function runRetention(pool, { retentionDays, recoveryDays } = retentionConfig()) {
   await pool.query(
-    `UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval
-     WHERE deleted_at IS NULL AND (
-       created_at < NOW() - ($1::text || ' days')::interval
-       OR parent IN (SELECT id FROM comments WHERE deleted_at IS NOT NULL)
-     )`,
+    "UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval WHERE deleted_at IS NULL AND created_at < NOW() - ($1::text || ' days')::interval",
     [retentionDays, recoveryDays],
   );
+  await softDeleteRepliesOfDeletedParents(pool, recoveryDays);
+  await pool.query("DELETE FROM comments WHERE deleted_at IS NOT NULL AND purge_after <= NOW() AND parent IS NOT NULL");
   await pool.query("DELETE FROM comments WHERE deleted_at IS NOT NULL AND purge_after <= NOW()");
 }
 
-module.exports = { ensureRetentionColumns, retentionConfig, runRetention, softDeleteComment };
+module.exports = {
+  ensureRetentionColumns,
+  retentionConfig,
+  runRetention,
+  softDeleteComment,
+  softDeleteRepliesOfDeletedParents,
+};

--- a/server/retention.js
+++ b/server/retention.js
@@ -19,6 +19,22 @@ async function softDeleteComment(pool, id, recoveryDays) {
   return rows[0] || null;
 }
 
+async function softDeleteCommentThread(pool, id, recoveryDays) {
+  const { rows } = await pool.query(
+    `WITH RECURSIVE thread AS (
+       SELECT id FROM comments WHERE id = $1
+       UNION ALL
+       SELECT c.id FROM comments c JOIN thread t ON c.parent = t.id
+     )
+     UPDATE comments
+     SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval
+     WHERE deleted_at IS NULL AND id IN (SELECT id FROM thread)
+     RETURNING *`,
+    [id, recoveryDays],
+  );
+  return rows.find((row) => row.id === id) || null;
+}
+
 async function softDeleteRepliesOfDeletedParents(pool, recoveryDays) {
   while (true) {
     const result = await pool.query(
@@ -46,5 +62,6 @@ module.exports = {
   retentionConfig,
   runRetention,
   softDeleteComment,
+  softDeleteCommentThread,
   softDeleteRepliesOfDeletedParents,
 };

--- a/server/retention.js
+++ b/server/retention.js
@@ -13,7 +13,7 @@ async function ensureRetentionColumns(pool) {
 
 async function softDeleteComment(pool, id, recoveryDays) {
   const { rows } = await pool.query(
-    "UPDATE comments SET deleted_at = COALESCE(deleted_at, NOW()), purge_after = COALESCE(purge_after, NOW() + ($2::text || ' days')::interval) WHERE id = $1 RETURNING *",
+    "UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval WHERE id = $1 AND deleted_at IS NULL RETURNING *",
     [id, recoveryDays],
   );
   return rows[0] || null;
@@ -21,7 +21,11 @@ async function softDeleteComment(pool, id, recoveryDays) {
 
 async function runRetention(pool, { retentionDays, recoveryDays } = retentionConfig()) {
   await pool.query(
-    "UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval WHERE deleted_at IS NULL AND created_at < NOW() - ($1::text || ' days')::interval",
+    `UPDATE comments SET deleted_at = NOW(), purge_after = NOW() + ($2::text || ' days')::interval
+     WHERE deleted_at IS NULL AND (
+       created_at < NOW() - ($1::text || ' days')::interval
+       OR parent IN (SELECT id FROM comments WHERE deleted_at IS NOT NULL)
+     )`,
     [retentionDays, recoveryDays],
   );
   await pool.query("DELETE FROM comments WHERE deleted_at IS NOT NULL AND purge_after <= NOW()");

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -1312,6 +1312,51 @@ describe("API", async () => {
       assert.equal(reply.status, 404);
     });
 
+    it("retention soft-deletes old parent threads and purges children before parents", async () => {
+      const { runRetention } = await import("./retention.js");
+      const parent = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            uri: "https://example.com/retention-thread",
+            quote: "q",
+            body: "parent",
+            author: "a",
+          }),
+        })
+      ).json();
+      const reply = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            uri: "https://example.com/retention-thread",
+            body: "reply",
+            author: "a",
+            parent: parent.id,
+          }),
+        })
+      ).json();
+      await pool.query("UPDATE comments SET created_at = NOW() - INTERVAL '10 days' WHERE id = $1", [parent.id]);
+      await runRetention(pool, { retentionDays: 1, recoveryDays: 30 });
+      const retained = await pool.query("SELECT id, deleted_at FROM comments WHERE id = ANY($1)", [
+        [parent.id, reply.id],
+      ]);
+      assert.equal(retained.rows.length, 2);
+      retained.rows.forEach((row) => assert.ok(row.deleted_at));
+
+      const visible = await (await fetch(`${BASE}/comments?document=${parent.document}`)).json();
+      assert.deepEqual(visible.data, []);
+
+      await pool.query("UPDATE comments SET purge_after = NOW() - INTERVAL '1 minute' WHERE id = ANY($1)", [
+        [parent.id, reply.id],
+      ]);
+      await runRetention(pool, { retentionDays: 1, recoveryDays: 30 });
+      const purged = await pool.query("SELECT id FROM comments WHERE id = ANY($1)", [[parent.id, reply.id]]);
+      assert.equal(purged.rows.length, 0);
+    });
+
     it("status filters do not leak soft-deleted replies", async () => {
       const parent = await (
         await fetch(`${BASE}/comments`, {

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -1310,6 +1310,52 @@ describe("API", async () => {
       assert.equal(nested.status, 404);
     });
 
+    it("soft-deletes legacy nested descendants on explicit parent delete", async () => {
+      const parent = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri: "https://example.com/legacy-nested", quote: "q", body: "parent", author: "a" }),
+        })
+      ).json();
+      const reply = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            uri: "https://example.com/legacy-nested",
+            body: "reply",
+            author: "a",
+            parent: parent.id,
+          }),
+        })
+      ).json();
+      const grandchildId = `cmt_legacy_${Date.now()}`;
+      await pool.query(
+        `INSERT INTO comments (id, document, parent, quote, prefix, suffix, body, author, status)
+         VALUES ($1, $2, $3, '', NULL, NULL, 'legacy nested', 'a', NULL)`,
+        [grandchildId, parent.document, reply.id],
+      );
+
+      const deleted = await fetch(`${BASE}/comments/${parent.id}`, { method: "DELETE" });
+      assert.equal(deleted.status, 200);
+      const rows = await pool.query("SELECT id, deleted_at, purge_after FROM comments WHERE id = ANY($1) ORDER BY id", [
+        [parent.id, reply.id, grandchildId],
+      ]);
+      assert.equal(rows.rows.length, 3);
+      for (const row of rows.rows) {
+        assert.ok(row.deleted_at);
+        assert.ok(row.purge_after);
+      }
+
+      const react = await fetch(`${BASE}/comments/${grandchildId}/reactions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emoji: "👍", author: "a" }),
+      });
+      assert.equal(react.status, 404);
+    });
+
     it("does not allow reactions or replies on soft-deleted comments", async () => {
       const c = await (
         await fetch(`${BASE}/comments`, {

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -1267,6 +1267,78 @@ describe("API", async () => {
     });
   });
 
+  describe("comment retention and soft delete", () => {
+    it("soft-deletes comments, hides them, and makes repeated delete 404", async () => {
+      const c = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri: "https://example.com/soft-delete", quote: "q", body: "b", author: "a" }),
+        })
+      ).json();
+
+      const del = await fetch(`${BASE}/comments/${c.id}`, { method: "DELETE" });
+      assert.equal(del.status, 200);
+      const { rows } = await pool.query("SELECT deleted_at, purge_after FROM comments WHERE id = $1", [c.id]);
+      assert.ok(rows[0].deleted_at);
+      assert.ok(rows[0].purge_after);
+
+      assert.equal((await fetch(`${BASE}/comments/${c.id}`)).status, 404);
+      assert.equal((await fetch(`${BASE}/comments/${c.id}`, { method: "DELETE" })).status, 404);
+    });
+
+    it("does not allow reactions or replies on soft-deleted comments", async () => {
+      const c = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri: "https://example.com/deleted-mutate", quote: "q", body: "b", author: "a" }),
+        })
+      ).json();
+      await fetch(`${BASE}/comments/${c.id}`, { method: "DELETE" });
+
+      const reaction = await fetch(`${BASE}/comments/${c.id}/reactions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ emoji: "👍", author: "a" }),
+      });
+      assert.equal(reaction.status, 404);
+
+      const reply = await fetch(`${BASE}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ uri: "https://example.com/deleted-mutate", body: "reply", author: "a", parent: c.id }),
+      });
+      assert.equal(reply.status, 404);
+    });
+
+    it("status filters do not leak soft-deleted replies", async () => {
+      const parent = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri: "https://example.com/status-soft", quote: "q", body: "parent", author: "a" }),
+        })
+      ).json();
+      const reply = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            uri: "https://example.com/status-soft",
+            body: "reply",
+            author: "a",
+            parent: parent.id,
+          }),
+        })
+      ).json();
+      await fetch(`${BASE}/comments/${reply.id}`, { method: "DELETE" });
+      const res = await fetch(`${BASE}/comments?status=open`);
+      const json = await res.json();
+      assert.ok(!json.data.some((comment) => comment.id === reply.id));
+    });
+  });
+
   // ── Reactions ────────────────────────────────────────────────────
 
   describe("POST /comments/:id/reactions", () => {

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -104,6 +104,21 @@ describe("sanitize", async () => {
   });
 });
 
+describe("retention", async () => {
+  const { retentionConfig } = await import("./retention.js");
+
+  it("reads configurable retention and recovery windows", () => {
+    assert.deepEqual(retentionConfig({ REMARQ_COMMENT_RETENTION_DAYS: "45", REMARQ_COMMENT_RECOVERY_DAYS: "7" }), {
+      retentionDays: 45,
+      recoveryDays: 7,
+    });
+  });
+
+  it("uses safe defaults", () => {
+    assert.deepEqual(retentionConfig({}), { retentionDays: 365, recoveryDays: 30 });
+  });
+});
+
 describe("validate-color", async () => {
   const { validateColor } = await import("./validate-color.js");
 

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -1287,6 +1287,29 @@ describe("API", async () => {
       assert.equal((await fetch(`${BASE}/comments/${c.id}`, { method: "DELETE" })).status, 404);
     });
 
+    it("rejects replies to replies so threads stay one level deep", async () => {
+      const parent = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri: "https://example.com/no-nested", quote: "q", body: "parent", author: "a" }),
+        })
+      ).json();
+      const reply = await (
+        await fetch(`${BASE}/comments`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ uri: "https://example.com/no-nested", body: "reply", author: "a", parent: parent.id }),
+        })
+      ).json();
+      const nested = await fetch(`${BASE}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ uri: "https://example.com/no-nested", body: "nested", author: "a", parent: reply.id }),
+      });
+      assert.equal(nested.status, 404);
+    });
+
     it("does not allow reactions or replies on soft-deleted comments", async () => {
       const c = await (
         await fetch(`${BASE}/comments`, {


### PR DESCRIPTION
## What changed

Added comment soft-delete fields, configurable active/recovery retention windows, retention purge on startup, soft-delete behavior for comment deletion, and lifecycle docs.

## Why

Closes #280. Block Security requires configurable retention, soft delete, and a recovery period before permanent removal.

## New/Changed Endpoints

No endpoints changed. `DELETE /comments/:id` now soft-deletes comments and replies before later purge.

## How to verify

- `npm run check`
- Delete a comment and confirm `deleted_at`/`purge_after` are set and list/read endpoints exclude it.

## Manual testing checklist

- [ ] Server starts without errors (`npm run start`)
- [x] Existing tests pass (`npm test`)
- [ ] Tested in browser (annotations, sidebar, highlights work)
- [ ] Tested API changes with curl (include example commands above)
- [ ] No console errors in browser DevTools
