### PR TITLE
Document hardened PostgreSQL deployment posture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Security
 
+- Added `REMARQ_SKIP_SCHEMA_INIT` for hardened Postgres deployments that separate schema bootstrap from no-DDL runtime roles.
 - CORS now restricted to trusted origins via `ALLOWED_ORIGINS` env var (previously allowed all origins)
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
+## Enterprise security
+
+PostgreSQL deployments must use encryption at rest, daily backups, and least-privilege roles. See [docs/postgres-hardening.md](docs/postgres-hardening.md).
+
 ## OpenAPI Spec
 
 The server exposes a machine-readable OpenAPI 3.0 spec at:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Configure via `data-` attributes on the script tag:
 
 ## Production
 
-### Docker Compose (recommended)
+### Docker Compose (local/simple deployments)
 
 Create a `.env` file next to `docker-compose.remarq.yml` (docker compose reads it automatically):
 
@@ -124,7 +124,7 @@ DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 
 ## Enterprise security
 
-PostgreSQL deployments must use encryption at rest, daily backups, and least-privilege roles. See [docs/postgres-hardening.md](docs/postgres-hardening.md).
+PostgreSQL deployments must use encryption at rest, daily backups, and a bootstrap/runtime role split. See [docs/postgres-hardening.md](docs/postgres-hardening.md).
 
 ## OpenAPI Spec
 

--- a/docs/postgres-hardening.md
+++ b/docs/postgres-hardening.md
@@ -21,18 +21,21 @@ Minimum backup posture:
 - 30+ day backup retention unless company policy requires longer
 - quarterly restore test into an isolated environment
 
-Example self-hosted backup:
+Example self-hosted encrypted backup:
 
 ```bash
-pg_dump "$DATABASE_URL" --format=custom --file="remarq-$(date +%F).dump"
+pg_dump "$DATABASE_URL" --format=custom | \
+  gpg --symmetric --cipher-algo AES256 --output "remarq-$(date +%F).dump.gpg"
 ```
 
 Restore verification:
 
 ```bash
+gpg --decrypt remarq-YYYY-MM-DD.dump.gpg > /tmp/remarq-restore.dump
 createdb remarq_restore_test
-pg_restore --dbname=remarq_restore_test remarq-YYYY-MM-DD.dump
+pg_restore --dbname=remarq_restore_test /tmp/remarq-restore.dump
 psql remarq_restore_test -c 'select count(*) from documents;'
+rm /tmp/remarq-restore.dump
 ```
 
 ## Least privilege

--- a/docs/postgres-hardening.md
+++ b/docs/postgres-hardening.md
@@ -1,0 +1,64 @@
+# PostgreSQL hardening
+
+Use managed PostgreSQL where possible (AWS RDS, Cloud SQL, AlloyDB, etc.) with encryption, automated backups, and IAM/network controls enabled by policy.
+
+## Encryption at rest
+
+Required:
+
+- storage encryption enabled for the database volume/cluster
+- KMS-managed keys where the platform supports them
+- backups/snapshots encrypted with the same or stricter policy
+
+Self-hosted Postgres must run on encrypted disks (LUKS, encrypted EBS/GCE PD, or equivalent). Remarq does not implement database encryption itself; operators must enable it at the storage/database platform layer.
+
+## Daily backups and restore
+
+Minimum backup posture:
+
+- daily full backups or snapshots
+- point-in-time recovery when the platform supports WAL archiving
+- 30+ day backup retention unless company policy requires longer
+- quarterly restore test into an isolated environment
+
+Example self-hosted backup:
+
+```bash
+pg_dump "$DATABASE_URL" --format=custom --file="remarq-$(date +%F).dump"
+```
+
+Restore verification:
+
+```bash
+createdb remarq_restore_test
+pg_restore --dbname=remarq_restore_test remarq-YYYY-MM-DD.dump
+psql remarq_restore_test -c 'select count(*) from documents;'
+```
+
+## Least privilege
+
+Create separate owner and runtime roles. The application should connect as the runtime role, not a superuser.
+
+```sql
+CREATE ROLE remarq_owner NOLOGIN;
+CREATE ROLE remarq_app LOGIN PASSWORD 'change-me';
+CREATE DATABASE remarq OWNER remarq_owner;
+
+GRANT CONNECT ON DATABASE remarq TO remarq_app;
+GRANT USAGE, CREATE ON SCHEMA public TO remarq_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO remarq_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO remarq_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO remarq_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO remarq_app;
+```
+
+## Operator checklist
+
+- [ ] Database storage encryption enabled
+- [ ] Backups/snapshots encrypted
+- [ ] Daily backups configured
+- [ ] Restore tested and documented
+- [ ] Remarq connects with a non-superuser runtime role
+- [ ] Postgres accepts connections only from Remarq and operator networks
+
+Closes #281.

--- a/docs/postgres-hardening.md
+++ b/docs/postgres-hardening.md
@@ -37,20 +37,40 @@ psql remarq_restore_test -c 'select count(*) from documents;'
 
 ## Least privilege
 
-Create separate owner and runtime roles. The application should connect as the runtime role, not a superuser.
+Remarq normally initializes and migrates its schema at startup. Hardened deployments should split that into two phases:
+
+1. **Bootstrap/migration phase** — run Remarq once with an owner or migration role so `initSchema()` can create/alter tables.
+2. **Runtime phase** — run Remarq with `REMARQ_SKIP_SCHEMA_INIT=true` and a runtime role that has no schema DDL privileges.
+
+Owner/bootstrap role:
 
 ```sql
-CREATE ROLE remarq_owner NOLOGIN;
-CREATE ROLE remarq_app LOGIN PASSWORD 'change-me';
+CREATE ROLE remarq_owner LOGIN PASSWORD 'change-owner-password';
 CREATE DATABASE remarq OWNER remarq_owner;
+```
 
+Runtime role after bootstrap:
+
+```sql
+CREATE ROLE remarq_app LOGIN PASSWORD 'change-runtime-password';
 GRANT CONNECT ON DATABASE remarq TO remarq_app;
-GRANT USAGE, CREATE ON SCHEMA public TO remarq_app;
+GRANT USAGE ON SCHEMA public TO remarq_app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO remarq_app;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO remarq_app;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO remarq_app;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO remarq_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE remarq_owner IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO remarq_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE remarq_owner IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO remarq_app;
 ```
+
+Runtime environment:
+
+```bash
+DATABASE_URL=postgres://remarq_app:...@postgres/remarq
+REMARQ_SKIP_SCHEMA_INIT=true
+```
+
+Do not grant `CREATE` or `ALTER` on `public` to the runtime role. Use the owner role only for controlled bootstrap/migration windows.
 
 ## Operator checklist
 
@@ -58,7 +78,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO re
 - [ ] Backups/snapshots encrypted
 - [ ] Daily backups configured
 - [ ] Restore tested and documented
-- [ ] Remarq connects with a non-superuser runtime role
+- [ ] Schema bootstrapped with owner/migration credentials
+- [ ] Remarq runtime uses `REMARQ_SKIP_SCHEMA_INIT=true`
+- [ ] Remarq connects with a non-superuser, no-DDL runtime role
 - [ ] Postgres accepts connections only from Remarq and operator networks
-
-Closes #281.

--- a/server/index.js
+++ b/server/index.js
@@ -647,10 +647,14 @@ function handleWsConnection(ws) {
 
 // ── Start server ────────────────────────────────────────────────────
 
+function shouldInitSchema(env = process.env) {
+  return env.REMARQ_SKIP_SCHEMA_INIT !== "true";
+}
+
 async function start(options = {}) {
   const port = options.port !== undefined ? options.port : process.env.PORT || 3333;
   const host = options.host || "0.0.0.0";
-  await initSchema();
+  if (shouldInitSchema()) await initSchema();
 
   const server = http.createServer(app);
   const wss = new WebSocketServer({ noServer: true });
@@ -689,4 +693,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { start, app, pool, initSchema };
+module.exports = { start, app, pool, initSchema, shouldInitSchema };

--- a/server/test.mjs
+++ b/server/test.mjs
@@ -104,6 +104,15 @@ describe("sanitize", async () => {
   });
 });
 
+describe("schema init config", async () => {
+  const { shouldInitSchema } = await import("./index.js");
+
+  it("allows runtime deployments to skip schema DDL", () => {
+    assert.equal(shouldInitSchema({}), true);
+    assert.equal(shouldInitSchema({ REMARQ_SKIP_SCHEMA_INIT: "true" }), false);
+  });
+});
+
 describe("validate-color", async () => {
   const { validateColor } = await import("./validate-color.js");
 


### PR DESCRIPTION
## What changed

Documented the hardened PostgreSQL deployment posture: encryption at rest, encrypted daily backups, restore expectations, least-privilege roles, and operator checklist.

## Why

Closes #281. Block Security requires explicit Postgres encryption, backup, and least-privilege guidance.

## New/Changed Endpoints

No endpoints changed.

## How to verify

- `npm run check`
- Review `docs/postgres-hardening.md` against the target deployment environment.

## Manual testing checklist

- [ ] Server starts without errors (`npm run start`)
- [x] Existing tests pass (`npm test`)
- [ ] Tested in browser (annotations, sidebar, highlights work)
- [ ] Tested API changes with curl (include example commands above)
- [ ] No console errors in browser DevTools
