### PR TITLE
Add enterprise deployment and security documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Docs
 
+- Added enterprise deployment, security controls, and incident response documentation that maps each control to Remarq or the surrounding enterprise platform.
 - `CLAUDE.md` renamed to `AGENTS.md` (pi-preferred filename) and simplified to pointers to `agents/implementor/AGENTS.md` (workflow) and `PRINCIPLES.md` (engineering principles). Principles extracted to dedicated `PRINCIPLES.md`, eliminating duplication across agent files.
 - Added Environment Variables table to README
 - Added webhook agent integration pattern to best-practices guide

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ npm install --prefix server
 DATABASE_URL=postgres://user:pass@localhost:5432/remarq node server/index.js
 ```
 
+## Enterprise operations
+
+- [Enterprise deployment guide](docs/enterprise-deployment.md)
+- [Security controls](docs/security-controls.md)
+- [Incident response](docs/incident-response.md)
+
 ## OpenAPI Spec
 
 The server exposes a machine-readable OpenAPI 3.0 spec at:

--- a/docs/enterprise-deployment.md
+++ b/docs/enterprise-deployment.md
@@ -1,43 +1,42 @@
 # Enterprise deployment guide
 
-This is the supported Remarq architecture for internal enterprise use.
+This guide describes the supported enterprise boundary for Remarq today. Remarq provides the annotation API and Postgres-backed persistence; enterprise access controls are enforced by the surrounding platform.
 
 ```text
-VPN/corporate network -> TLS 1.2+ reverse proxy -> Remarq server -> private PostgreSQL
-                                   |-> Okta SSO / trusted identity header
+VPN/corporate network -> TLS reverse proxy / SSO gateway -> Remarq server -> private PostgreSQL
 ```
 
-## Required controls
+## Control ownership
 
-- Internal network only; no public internet exposure
-- HTTPS-only access with TLS 1.2+
-- Okta SSO or trusted corporate auth proxy
-- RBAC enabled for comments and user management
-- PostgreSQL encryption at rest, daily backups, and least-privilege runtime role
-- Audit logs retained for at least 90 days
-- Comment retention configured for company policy
+| Control                                       | Enforced by                                                                     |
+| --------------------------------------------- | ------------------------------------------------------------------------------- |
+| Private network / no public internet exposure | firewall, VPN, load balancer, Kubernetes ingress, or corporate network controls |
+| TLS 1.2+ and certificates                     | reverse proxy or load balancer                                                  |
+| User authentication / SSO                     | Okta, identity-aware proxy, or corporate SSO gateway in front of Remarq         |
+| Access logs                                   | reverse proxy, IdP, platform logs                                               |
+| Data encryption at rest                       | PostgreSQL/storage platform                                                     |
+| Backups and restores                          | PostgreSQL/storage platform                                                     |
+| CORS origin policy                            | Remarq `ALLOWED_ORIGINS`                                                        |
+| Webhook authenticity                          | Remarq HMAC webhook signatures                                                  |
 
 ## Deployment steps
 
 1. Provision encrypted PostgreSQL on a private network.
-2. Create least-privilege Remarq runtime database credentials.
-3. Deploy Remarq bound to loopback/container-private network.
-4. Put an internal TLS reverse proxy in front of Remarq.
-5. Configure Okta SSO or a trusted auth proxy.
-6. Set environment variables for auth, HTTPS enforcement, audit retention, and comment retention.
-7. Verify from outside VPN/corporate network that the service is unreachable.
+2. Deploy Remarq so it is reachable only by the internal proxy/gateway.
+3. Configure the proxy for TLS 1.2+ and corporate certificate policy.
+4. Configure Okta/SSO at the proxy or gateway. Do not expose Remarq directly.
+5. Set `ALLOWED_ORIGINS` to the approved internal site origins.
+6. Verify public internet sources cannot reach Remarq or Postgres.
+7. Verify backup restore in an isolated environment.
 
-## Environment checklist
+## Remarq environment
 
 ```bash
 DATABASE_URL=postgres://remarq_app:...@postgres/remarq
+PORT=3333
 ALLOWED_ORIGINS=https://remarq.internal.example.com
-REMARQ_ENFORCE_HTTPS=true
-REMARQ_AUTH_REQUIRED=true
-REMARQ_SESSION_TIMEOUT_MINUTES=480
-REMARQ_AUDIT_RETENTION_DAYS=90
-REMARQ_COMMENT_RETENTION_DAYS=365
-REMARQ_COMMENT_RECOVERY_DAYS=30
 ```
 
-Closes #282.
+## Current limitations
+
+Remarq does not currently provide native user accounts, native Okta login, native RBAC, native audit-log export, or native comment-retention enforcement on `main`. Enterprise deployments must enforce those controls upstream or through the database/platform until dedicated Remarq features are merged.

--- a/docs/enterprise-deployment.md
+++ b/docs/enterprise-deployment.md
@@ -1,0 +1,43 @@
+# Enterprise deployment guide
+
+This is the supported Remarq architecture for internal enterprise use.
+
+```text
+VPN/corporate network -> TLS 1.2+ reverse proxy -> Remarq server -> private PostgreSQL
+                                   |-> Okta SSO / trusted identity header
+```
+
+## Required controls
+
+- Internal network only; no public internet exposure
+- HTTPS-only access with TLS 1.2+
+- Okta SSO or trusted corporate auth proxy
+- RBAC enabled for comments and user management
+- PostgreSQL encryption at rest, daily backups, and least-privilege runtime role
+- Audit logs retained for at least 90 days
+- Comment retention configured for company policy
+
+## Deployment steps
+
+1. Provision encrypted PostgreSQL on a private network.
+2. Create least-privilege Remarq runtime database credentials.
+3. Deploy Remarq bound to loopback/container-private network.
+4. Put an internal TLS reverse proxy in front of Remarq.
+5. Configure Okta SSO or a trusted auth proxy.
+6. Set environment variables for auth, HTTPS enforcement, audit retention, and comment retention.
+7. Verify from outside VPN/corporate network that the service is unreachable.
+
+## Environment checklist
+
+```bash
+DATABASE_URL=postgres://remarq_app:...@postgres/remarq
+ALLOWED_ORIGINS=https://remarq.internal.example.com
+REMARQ_ENFORCE_HTTPS=true
+REMARQ_AUTH_REQUIRED=true
+REMARQ_SESSION_TIMEOUT_MINUTES=480
+REMARQ_AUDIT_RETENTION_DAYS=90
+REMARQ_COMMENT_RETENTION_DAYS=365
+REMARQ_COMMENT_RECOVERY_DAYS=30
+```
+
+Closes #282.

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -1,0 +1,32 @@
+# Incident response
+
+## Severity triggers
+
+Treat these as security incidents:
+
+- suspected unauthorized Remarq access
+- public internet exposure of Remarq or Postgres
+- leaked `DATABASE_URL`, Okta client secret, webhook secret, or backup
+- audit log tampering or unexplained gaps
+- data deletion outside approved retention policy
+
+## Response process
+
+1. **Contain** — remove public ingress, rotate secrets, disable suspicious users, or stop the service if needed.
+2. **Preserve evidence** — export audit events, reverse proxy logs, Okta logs, Postgres logs, and deployment history.
+3. **Assess blast radius** — identify actors, documents, comments, and time window affected.
+4. **Recover** — restore from verified backup when integrity is in doubt.
+5. **Notify** — follow the owning organization's security notification policy.
+6. **Postmortem** — document root cause, timeline, customer/user impact, and corrective actions.
+
+## Operator escalation packet
+
+Include:
+
+- incident start/end times
+- affected environment and URL
+- audit log export
+- Okta sign-in events for affected users
+- reverse proxy access logs
+- database backup/restore status
+- deployed Remarq commit SHA

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -4,20 +4,30 @@
 
 Treat these as security incidents:
 
-- suspected unauthorized Remarq access
-- public internet exposure of Remarq or Postgres
-- leaked `DATABASE_URL`, Okta client secret, webhook secret, or backup
-- audit log tampering or unexplained gaps
-- data deletion outside approved retention policy
+- suspected unauthorized Remarq access through the proxy/gateway
+- public internet exposure of Remarq or PostgreSQL
+- leaked `DATABASE_URL`, webhook secret, database credentials, or backup
+- unexplained gaps in proxy, IdP, platform, or database logs
+- data deletion outside approved operator process
+
+## Evidence sources
+
+Remarq does not currently provide a native audit-log export on `main`. Preserve evidence from:
+
+- reverse proxy / load balancer access logs
+- Okta or identity-provider sign-in logs
+- deployment platform events and deployed commit SHA
+- PostgreSQL logs and backups
+- webhook receiver logs, if webhooks were involved
 
 ## Response process
 
-1. **Contain** — remove public ingress, rotate secrets, disable suspicious users, or stop the service if needed.
-2. **Preserve evidence** — export audit events, reverse proxy logs, Okta logs, Postgres logs, and deployment history.
-3. **Assess blast radius** — identify actors, documents, comments, and time window affected.
+1. **Contain** — remove public ingress, rotate secrets, disable suspicious IdP users, or stop the service if needed.
+2. **Preserve evidence** — export proxy logs, IdP logs, PostgreSQL logs, deployment history, and relevant backups.
+3. **Assess blast radius** — identify actors, documents, comments, and time window affected from the preserved logs and database state.
 4. **Recover** — restore from verified backup when integrity is in doubt.
 5. **Notify** — follow the owning organization's security notification policy.
-6. **Postmortem** — document root cause, timeline, customer/user impact, and corrective actions.
+6. **Postmortem** — document root cause, timeline, impact, and corrective actions.
 
 ## Operator escalation packet
 
@@ -25,8 +35,7 @@ Include:
 
 - incident start/end times
 - affected environment and URL
-- audit log export
-- Okta sign-in events for affected users
-- reverse proxy access logs
+- proxy/IdP/database log exports
 - database backup/restore status
 - deployed Remarq commit SHA
+- containment actions already taken

--- a/docs/security-controls.md
+++ b/docs/security-controls.md
@@ -1,0 +1,30 @@
+# Security controls
+
+## Access control
+
+- Anonymous access disabled in enterprise deployments.
+- Okta SSO authenticates users.
+- RBAC gates read, create, edit-own, resolve, delete, and user-management actions.
+
+## Transport and network
+
+- HTTPS-only with TLS 1.2+ at the internal reverse proxy.
+- Remarq is reachable only from VPN/corporate network paths.
+- Postgres is private to Remarq and operator networks.
+
+## Data protection
+
+- PostgreSQL encryption at rest is required.
+- Daily encrypted backups are required.
+- Comment retention and soft-delete recovery windows are configurable.
+
+## Auditability
+
+- Comment create/update/status/delete events are logged.
+- Document access is logged.
+- Audit events include actor, action, target, metadata, and timestamp.
+- Audit logs retain for at least 90 days.
+
+## Verification
+
+Operators should verify these controls before production approval and after any deployment topology change.

--- a/docs/security-controls.md
+++ b/docs/security-controls.md
@@ -1,30 +1,33 @@
 # Security controls
 
-## Access control
+This page separates controls Remarq provides today from controls the enterprise platform must provide around it.
 
-- Anonymous access disabled in enterprise deployments.
-- Okta SSO authenticates users.
-- RBAC gates read, create, edit-own, resolve, delete, and user-management actions.
+## Provided by Remarq
 
-## Transport and network
+- API persistence in PostgreSQL via `DATABASE_URL`
+- CORS allowlist via `ALLOWED_ORIGINS`
+- Security headers from Helmet
+- HMAC signatures on outbound webhook payloads
+- Health check at `/health`
 
-- HTTPS-only with TLS 1.2+ at the internal reverse proxy.
-- Remarq is reachable only from VPN/corporate network paths.
-- Postgres is private to Remarq and operator networks.
+## Required external controls
 
-## Data protection
+### Access control
 
-- PostgreSQL encryption at rest is required.
-- Daily encrypted backups are required.
-- Comment retention and soft-delete recovery windows are configurable.
+Place Remarq behind an SSO-aware reverse proxy, identity-aware proxy, or VPN/corporate network gateway. The proxy must reject anonymous traffic before it reaches Remarq.
 
-## Auditability
+### Transport and network
 
-- Comment create/update/status/delete events are logged.
-- Document access is logged.
-- Audit events include actor, action, target, metadata, and timestamp.
-- Audit logs retain for at least 90 days.
+Terminate TLS 1.2+ at an internal proxy or load balancer. Restrict inbound access to VPN/corporate networks. Keep PostgreSQL private to Remarq and operator networks.
+
+### Data protection
+
+Enable PostgreSQL/storage encryption at rest. Configure encrypted backups and periodic restore tests in the database platform.
+
+### Auditability
+
+Collect access logs from the reverse proxy, identity provider, deployment platform, and PostgreSQL. Retain those logs according to the organization's audit policy.
 
 ## Verification
 
-Operators should verify these controls before production approval and after any deployment topology change.
+Operators should verify each control at its enforcement point before production approval and after any topology change.


### PR DESCRIPTION
## What changed

Added enterprise deployment guide, security controls documentation, and incident response procedures; linked them from the README.

## Why

Closes #282. Block Security requested enterprise-ready deployment, controls, and escalation documentation before integration.

## New/Changed Endpoints

No endpoints changed.

## How to verify

- `npm run check`
- Review the new docs under `docs/`.

## Manual testing checklist

- [ ] Server starts without errors (`npm run start`)
- [x] Existing tests pass (`npm test`)
- [ ] Tested in browser (annotations, sidebar, highlights work)
- [ ] Tested API changes with curl (include example commands above)
- [ ] No console errors in browser DevTools
